### PR TITLE
Add simple login state management

### DIFF
--- a/Law4Hire.Web/Components/Layout/NavMenu.razor
+++ b/Law4Hire.Web/Components/Layout/NavMenu.razor
@@ -2,6 +2,7 @@
 @inject NavigationManager NavigationManager
 @inject IStringLocalizer<NavMenu> Localizer
 @inject Law4Hire.Web.State.CultureState CultureState
+@inject Law4Hire.Web.State.AuthState AuthState
 @using Microsoft.Extensions.Localization
 @using System.Globalization
 @implements IDisposable
@@ -38,9 +39,12 @@
                 <li class="nav-item">
                     <NavLink class="nav-link" href="immigrationLibrary">@Localizer["Library"]</NavLink>
                 </li>
-                <li class="nav-item">
-                    <NavLink class="nav-link" href="dashboard">@Localizer["Dashboard"]</NavLink>
-                </li>
+                @if (AuthState.IsLoggedIn)
+                {
+                    <li class="nav-item">
+                        <NavLink class="nav-link" href="dashboard">@Localizer["Dashboard"]</NavLink>
+                    </li>
+                }
             </ul>
             <!-- Right-aligned items -->
             <ul class="navbar-nav ms-auto align-items-center">
@@ -64,11 +68,20 @@
                         }
                     </ul>
                 </li>
-                <li class="nav-item">
-                    <NavLink class="nav-link" href="login">
-                        <span class="oi oi-account-login" aria-hidden="true"></span> @Localizer["Login"]
-                    </NavLink>
-                </li>
+                @if (!AuthState.IsLoggedIn)
+                {
+                    <li class="nav-item">
+                        <NavLink class="nav-link" href="login">
+                            <span class="oi oi-account-login" aria-hidden="true"></span> @Localizer["Login"]
+                        </NavLink>
+                    </li>
+                }
+                else if (AuthState.CurrentUser is not null)
+                {
+                    <li class="nav-item">
+                        <a class="nav-link" href="#" @onclick="Logout">Hello @AuthState.CurrentUser.FirstName</a>
+                    </li>
+                }
             </ul>
         </div>
     </nav>
@@ -81,6 +94,7 @@
     protected override void OnInitialized()
     {
         CultureState.OnChange += StateHasChanged;
+        AuthState.OnChange += StateHasChanged;
     }
 
     protected override void OnAfterRender(bool firstRender)
@@ -130,6 +144,12 @@
         collapseNavMenu = !collapseNavMenu;
     }
 
+    private void Logout()
+    {
+        AuthState.Logout();
+        NavigationManager.NavigateTo("/");
+    }
+
     private List<LanguageInfo> SupportedLanguages { get; } = new()
     {
         new("🇺🇸 English", "en-US"),
@@ -160,5 +180,6 @@
     public void Dispose()
     {
         CultureState.OnChange -= StateHasChanged;
+        AuthState.OnChange -= StateHasChanged;
     }
 }

--- a/Law4Hire.Web/Components/Pages/Login.razor
+++ b/Law4Hire.Web/Components/Pages/Login.razor
@@ -4,6 +4,7 @@
 @using System.ComponentModel.DataAnnotations
 @inject HttpClient Http
 @inject NavigationManager NavigationManager
+@inject Law4Hire.Web.State.AuthState AuthState
 
 <PageTitle>Login</PageTitle>
 
@@ -61,7 +62,16 @@
 
         if (response.IsSuccessStatusCode)
         {
-            NavigationManager.NavigateTo("/dashboard");
+            var loginResult = await response.Content.ReadFromJsonAsync<LoginResult>();
+            if (loginResult != null)
+            {
+                var user = await Http.GetFromJsonAsync<UserDto>($"api/users/{loginResult.UserId}");
+                if (user != null)
+                {
+                    AuthState.SetUser(user);
+                    NavigationManager.NavigateTo("/dashboard");
+                }
+            }
         }
         else
         {
@@ -70,4 +80,8 @@
 
         isLoading = false;
     }
+}
+
+@code {
+    private record LoginResult(Guid UserId, string Message);
 }

--- a/Law4Hire.Web/Program.cs
+++ b/Law4Hire.Web/Program.cs
@@ -9,6 +9,7 @@ builder.Services.AddRazorComponents()
     .AddInteractiveServerComponents();
 builder.Services.AddHttpContextAccessor();
 builder.Services.AddScoped<CultureState>();
+builder.Services.AddScoped<AuthState>();
 builder.Services.AddLocalization(options => options.ResourcesPath = "Resources");
 
 // ✅ Add this

--- a/Law4Hire.Web/State/AuthState.cs
+++ b/Law4Hire.Web/State/AuthState.cs
@@ -1,0 +1,26 @@
+using Law4Hire.Core.DTOs;
+
+namespace Law4Hire.Web.State;
+
+public class AuthState
+{
+    public UserDto? CurrentUser { get; private set; }
+
+    public bool IsLoggedIn => CurrentUser != null;
+
+    public event Action? OnChange;
+
+    public void SetUser(UserDto user)
+    {
+        CurrentUser = user;
+        NotifyStateChanged();
+    }
+
+    public void Logout()
+    {
+        CurrentUser = null;
+        NotifyStateChanged();
+    }
+
+    private void NotifyStateChanged() => OnChange?.Invoke();
+}


### PR DESCRIPTION
## Summary
- add `AuthState` service to hold logged in user
- register `AuthState` in the web app DI container
- update Login page to populate `AuthState` after successful login
- show Dashboard link only for authenticated users and greet them with a logout link

## Testing
- `pytest -q tests`

------
https://chatgpt.com/codex/tasks/task_e_686c27f11f0c833092a8c4962d837770