### PR TITLE
Fix Identity seeding

### DIFF
--- a/Law4Hire.Infrastructure/Data/Contexts/Law4HireDbContext.cs
+++ b/Law4Hire.Infrastructure/Data/Contexts/Law4HireDbContext.cs
@@ -38,13 +38,13 @@ public class Law4HireDbContext(DbContextOptions<Law4HireDbContext> options) : Db
 
         modelBuilder.Entity<UserDocumentStatus>()
         .HasOne(uds => uds.DocumentType)
-        .WithMany()
+        .WithMany(dt => dt.UserDocumentStatuses)
         .HasForeignKey(uds => uds.DocumentTypeId)
         .OnDelete(DeleteBehavior.Restrict); // or Cascade, based on your logic
 
         modelBuilder.Entity<VisaDocumentRequirement>()
             .HasOne(vdr => vdr.DocumentType)
-            .WithMany()
+            .WithMany(dt => dt.VisaDocumentRequirements)
             .OnDelete(DeleteBehavior.Restrict)
             .HasForeignKey(vdr => vdr.DocumentTypeId);
 


### PR DESCRIPTION
## Summary
- remove `RoleManager` and `UserManager` dependency from `DbInitializer`
- seed default users directly using `IAuthService`
- keep explicit relationship mappings for `DocumentType`

## Testing
- `dotnet test --no-build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686c249958a48330bd2597371a87fff1