### PR TITLE
Resolve compile warnings from DTO and entity definitions

### DIFF
--- a/Law4Hire.Core/DTOs/UserDtos.cs
+++ b/Law4Hire.Core/DTOs/UserDtos.cs
@@ -36,18 +36,19 @@ public record CreateUserDto(
     DateTime? DateOfBirth
 );
 
-public record UpdateUserDto(
-    string Email,
-    string? FirstName,
-    string? MiddleName,
-    string? LastName,
-    string? PhoneNumber,
-    string PreferredLanguage,
-    string? Address1,
-    string? Address2,
-    string? City,
-    string? State,
-    string? Country,
-    string? PostalCode,
-    DateTime? DateOfBirth
-);
+public record UpdateUserDto
+{
+    public string Email { get; set; } = string.Empty;
+    public string? FirstName { get; set; }
+    public string? MiddleName { get; set; }
+    public string? LastName { get; set; }
+    public string? PhoneNumber { get; set; }
+    public string PreferredLanguage { get; set; } = "en";
+    public string? Address1 { get; set; }
+    public string? Address2 { get; set; }
+    public string? City { get; set; }
+    public string? State { get; set; }
+    public string? Country { get; set; }
+    public string? PostalCode { get; set; }
+    public DateTime? DateOfBirth { get; set; }
+}

--- a/Law4Hire.Core/Entities/User.cs
+++ b/Law4Hire.Core/Entities/User.cs
@@ -5,13 +5,13 @@ namespace Law4Hire.Core.Entities;
 
 public class User : IdentityUser<Guid> // Inherits from IdentityUser with Guid as the key type
 {
-    public Guid Id { get; set; }
-    public string Email { get; set; } = default!;
-    public string UserName { get; set; } = string.Empty;
+    public new Guid Id { get; set; }
+    public new string Email { get; set; } = default!;
+    public new string UserName { get; set; } = string.Empty;
     public string? FirstName { get; set; }
     public string? MiddleName { get; set; }
     public string? LastName { get; set; }
-    public string? PhoneNumber { get; set; }
+    public new string? PhoneNumber { get; set; }
     public string PreferredLanguage { get; set; } = "en";
     public DateTime CreatedAt { get; set; } = DateTime.UtcNow;
     public bool IsActive { get; set; } = true;
@@ -24,7 +24,7 @@ public class User : IdentityUser<Guid> // Inherits from IdentityUser with Guid a
     public string? Country { get; set; }
     public string? PostalCode { get; set; }
     public DateTime? DateOfBirth { get; set; }
-    public byte[] PasswordHash { get; set; } = Array.Empty<byte>();
+    public new byte[] PasswordHash { get; set; } = Array.Empty<byte>();
     public byte[] PasswordSalt { get; set; } = Array.Empty<byte>();
     public ICollection<IntakeSession> IntakeSessions { get; set; } = new List<IntakeSession>();
     public ICollection<ServiceRequest> ServiceRequests { get; set; } = new List<ServiceRequest>();

--- a/Law4Hire.Infrastructure/Data/Contexts/Law4HireDbContext.cs
+++ b/Law4Hire.Infrastructure/Data/Contexts/Law4HireDbContext.cs
@@ -14,7 +14,6 @@ public class Law4HireDbContext : IdentityDbContext<User, IdentityRole<Guid>, Gui
     public Law4HireDbContext(DbContextOptions<Law4HireDbContext> options) : base(options)
     {
     }
-    public DbSet<User> Users { get; set; }
     public DbSet<ServicePackage> ServicePackages { get; set; }
     public DbSet<IntakeSession> IntakeSessions { get; set; }
     public DbSet<IntakeQuestion> IntakeQuestions { get; set; }

--- a/Law4Hire.Web/Components/Pages/Dashboard.razor
+++ b/Law4Hire.Web/Components/Pages/Dashboard.razor
@@ -130,21 +130,22 @@ else
         if (AuthState.CurrentUser != null)
         {
             var u = AuthState.CurrentUser;
-            editModel = new UpdateUserDto(
-                u.Email,
-                u.FirstName,
-                u.MiddleName,
-                u.LastName,
-                u.PhoneNumber,
-                u.PreferredLanguage,
-                u.Address1,
-                u.Address2,
-                u.City,
-                u.State,
-                u.Country,
-                u.PostalCode,
-                u.DateOfBirth
-            );
+            editModel = new UpdateUserDto
+            {
+                Email = u.Email,
+                FirstName = u.FirstName,
+                MiddleName = u.MiddleName,
+                LastName = u.LastName,
+                PhoneNumber = u.PhoneNumber,
+                PreferredLanguage = u.PreferredLanguage,
+                Address1 = u.Address1,
+                Address2 = u.Address2,
+                City = u.City,
+                State = u.State,
+                Country = u.Country,
+                PostalCode = u.PostalCode,
+                DateOfBirth = u.DateOfBirth
+            };
             documents = await Http.GetFromJsonAsync<List<DocumentInfo>>($"api/DocumentStatus/user/{u.Id}");
         }
     }


### PR DESCRIPTION
## Summary
- make `UpdateUserDto` mutable so Razor forms can edit it
- mark certain `User` properties with `new` to silence hiding warnings
- remove duplicate `Users` DbSet from context
- adjust dashboard initialization to use new DTO shape

## Testing
- `dotnet --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686c5abaad388330baf1dd9b153a7410