### PR TITLE
Fix IntakeSessionDto property mismatch

### DIFF
--- a/Law4Hire.API/Controllers/IntakeController.cs
+++ b/Law4Hire.API/Controllers/IntakeController.cs
@@ -41,7 +41,8 @@ public class IntakeController(IIntakeSessionRepository intakeSessionRepository) 
             createdSession.Status,
             createdSession.StartedAt,
             createdSession.CompletedAt,
-            createdSession.Language
+            createdSession.Language,
+            createdSession.SessionData
         );
 
         return CreatedAtAction(nameof(GetIntakeSession), new { id = createdSession.Id }, sessionDto);
@@ -67,7 +68,8 @@ public class IntakeController(IIntakeSessionRepository intakeSessionRepository) 
             session.Status,
             session.StartedAt,
             session.CompletedAt,
-            session.Language
+            session.Language,
+            session.SessionData
         );
 
         return Ok(sessionDto);
@@ -90,7 +92,8 @@ public class IntakeController(IIntakeSessionRepository intakeSessionRepository) 
             s.Status,
             s.StartedAt,
             s.CompletedAt,
-            s.Language
+            s.Language,
+            s.SessionData
         ));
 
         return Ok(sessionDtos);

--- a/Law4Hire.Application/Services/CoreServices.cs
+++ b/Law4Hire.Application/Services/CoreServices.cs
@@ -48,7 +48,8 @@ public class IntakeService(
             createdSession.Status,
             createdSession.StartedAt,
             createdSession.CompletedAt,
-            createdSession.Language
+            createdSession.Language,
+            createdSession.SessionData
         );
     }
 

--- a/Law4Hire.Core/DTOs/IntakeSessionDtos.cs
+++ b/Law4Hire.Core/DTOs/IntakeSessionDtos.cs
@@ -9,7 +9,8 @@ public record IntakeSessionDto(
     IntakeStatus Status,
     DateTime StartedAt,
     DateTime? CompletedAt,
-    string Language
+    string Language,
+    string? SessionData
 );
 
 public record CreateIntakeSessionDto(


### PR DESCRIPTION
## Summary
- add `SessionData` to `IntakeSessionDto`
- include session data when mapping sessions in `IntakeService` and `IntakeController`

## Testing
- `dotnet build Law4Hire.sln` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686c6d8372488330958ee37e4074a414