### PR TITLE
Add Immigrate option and update button layout

### DIFF
--- a/Law4Hire.Web/Components/Pages/Home.razor
+++ b/Law4Hire.Web/Components/Pages/Home.razor
@@ -17,10 +17,10 @@
 <div class="container mt-5">
     @if (!showInterview)
     {
-        <div class="row justify-content-center mb-5">
+        <div class="row justify-content-center mb-3">
             <div class="col-lg-8 text-center">
                 <h1 class="display-4 mb-4">@Localizer["WelcomeTitle"]</h1>
-                <p class="lead text-muted mb-5">@Localizer["WelcomeSubtitle"]</p>
+                <p class="lead text-muted mb-0">@Localizer["WelcomeSubtitle"]</p>
             </div>
         </div>
         
@@ -33,40 +33,47 @@
                         </div>
                         <h5>@Localizer["VisitUSA"]</h5>
                     </div>
-                    
-                    <div class="immigration-option" @onclick="() => StartInterview(ImmigrationGoal.Asylum)">
+
+                    <div class="immigration-option" @onclick="() => StartInterview(ImmigrationGoal.Immigrate)">
                         <div class="option-icon">
-                            <img src="/images/asylum-icon.png" alt="@Localizer["ApplyAsylum"]" />
+                            <img src="/images/GreenCard.png" alt="@Localizer["ImmigrateGreenCard"]" />
                         </div>
-                        <h5>@Localizer["ApplyAsylum"]</h5>
+                        <h5>@Localizer["ImmigrateGreenCard"]</h5>
                     </div>
-                    
-                    <div class="immigration-option" @onclick="() => StartInterview(ImmigrationGoal.Family)">
-                        <div class="option-icon">
-                            <img src="/images/family-icon.png" alt="@Localizer["JoinFamily"]" />
-                        </div>
-                        <h5>@Localizer["JoinFamily"]</h5>
-                    </div>
-                    
-                    <div class="immigration-option" @onclick="() => StartInterview(ImmigrationGoal.Study)">
-                        <div class="option-icon">
-                            <img src="/images/study-icon.png" alt="@Localizer["StudyUSA"]" />
-                        </div>
-                        <h5>@Localizer["StudyUSA"]</h5>
-                    </div>
-                    
+
                     <div class="immigration-option" @onclick="() => StartInterview(ImmigrationGoal.Investment)">
                         <div class="option-icon">
                             <img src="/images/invest-icon.png" alt="@Localizer["InvestUSA"]" />
                         </div>
                         <h5>@Localizer["InvestUSA"]</h5>
                     </div>
-                    
+
                     <div class="immigration-option" @onclick="() => StartInterview(ImmigrationGoal.Work)">
                         <div class="option-icon">
                             <img src="/images/work-icon.png" alt="@Localizer["WorkUSA"]" />
                         </div>
                         <h5>@Localizer["WorkUSA"]</h5>
+                    </div>
+
+                    <div class="immigration-option" @onclick="() => StartInterview(ImmigrationGoal.Asylum)">
+                        <div class="option-icon">
+                            <img src="/images/asylum-icon.png" alt="@Localizer["ApplyAsylum"]" />
+                        </div>
+                        <h5>@Localizer["ApplyAsylum"]</h5>
+                    </div>
+
+                    <div class="immigration-option" @onclick="() => StartInterview(ImmigrationGoal.Study)">
+                        <div class="option-icon">
+                            <img src="/images/study-icon.png" alt="@Localizer["StudyUSA"]" />
+                        </div>
+                        <h5>@Localizer["StudyUSA"]</h5>
+                    </div>
+
+                    <div class="immigration-option" @onclick="() => StartInterview(ImmigrationGoal.Family)">
+                        <div class="option-icon">
+                            <img src="/images/family-icon.png" alt="@Localizer["JoinFamily"]" />
+                        </div>
+                        <h5>@Localizer["JoinFamily"]</h5>
                     </div>
                     
                     <div class="immigration-option login-option" @onclick="GoToLogin">
@@ -203,14 +210,15 @@
 </div>
 
 @code {
-    public enum ImmigrationGoal 
-    { 
-        Visit, 
-        Asylum, 
-        Family, 
-        Study, 
-        Investment, 
-        Work 
+    public enum ImmigrationGoal
+    {
+        Visit,
+        Immigrate,
+        Investment,
+        Work,
+        Asylum,
+        Study,
+        Family
     }
 
     private bool showInterview = false;
@@ -426,11 +434,12 @@
         return goal switch
         {
             ImmigrationGoal.Visit => Localizer["VisitDescription"],
-            ImmigrationGoal.Asylum => Localizer["AsylumDescription"],
-            ImmigrationGoal.Family => Localizer["FamilyDescription"],
-            ImmigrationGoal.Study => Localizer["StudyDescription"],
+            ImmigrationGoal.Immigrate => Localizer["ImmigrateDescription"],
             ImmigrationGoal.Investment => Localizer["InvestmentDescription"],
             ImmigrationGoal.Work => Localizer["WorkDescription"],
+            ImmigrationGoal.Asylum => Localizer["AsylumDescription"],
+            ImmigrationGoal.Study => Localizer["StudyDescription"],
+            ImmigrationGoal.Family => Localizer["FamilyDescription"],
             _ => ""
         };
     }

--- a/Law4Hire.Web/Resources/Components/Pages/Home.en-US.resx
+++ b/Law4Hire.Web/Resources/Components/Pages/Home.en-US.resx
@@ -17,10 +17,13 @@
   </data>
 
 	<!-- Immigration Options -->
-	<data name="VisitUSA" xml:space="preserve">
+        <data name="VisitUSA" xml:space="preserve">
     <value>Visit or Tour the USA</value>
   </data>
-	<data name="ApplyAsylum" xml:space="preserve">
+        <data name="ImmigrateGreenCard" xml:space="preserve">
+    <value>Immigrate / Green Card</value>
+  </data>
+        <data name="ApplyAsylum" xml:space="preserve">
     <value>Apply for Asylum</value>
   </data>
 	<data name="JoinFamily" xml:space="preserve">
@@ -106,10 +109,13 @@
   </data>
 
 	<!-- Goal Descriptions -->
-	<data name="VisitDescription" xml:space="preserve">
+        <data name="VisitDescription" xml:space="preserve">
     <value>Tourism, business visits, or temporary stays in the United States</value>
   </data>
-	<data name="AsylumDescription" xml:space="preserve">
+        <data name="ImmigrateDescription" xml:space="preserve">
+    <value>Permanent residency and green card options</value>
+  </data>
+        <data name="AsylumDescription" xml:space="preserve">
     <value>Seeking protection and safety in the United States</value>
   </data>
 	<data name="FamilyDescription" xml:space="preserve">

--- a/Law4Hire.Web/Resources/Components/Pages/Home.es-ES.resx
+++ b/Law4Hire.Web/Resources/Components/Pages/Home.es-ES.resx
@@ -17,10 +17,13 @@
   </data>
 
 	<!-- Immigration Options -->
-	<data name="VisitUSA" xml:space="preserve">
+        <data name="VisitUSA" xml:space="preserve">
     <value>Visitar o Conocer EE.UU.</value>
   </data>
-	<data name="ApplyAsylum" xml:space="preserve">
+        <data name="ImmigrateGreenCard" xml:space="preserve">
+    <value>Inmigrar / Tarjeta Verde</value>
+  </data>
+        <data name="ApplyAsylum" xml:space="preserve">
     <value>Solicitar Asilo</value>
   </data>
 	<data name="JoinFamily" xml:space="preserve">
@@ -106,10 +109,13 @@
   </data>
 
 	<!-- Goal Descriptions -->
-	<data name="VisitDescription" xml:space="preserve">
+        <data name="VisitDescription" xml:space="preserve">
     <value>Turismo, visitas de negocios o estadías temporales en Estados Unidos</value>
   </data>
-	<data name="AsylumDescription" xml:space="preserve">
+        <data name="ImmigrateDescription" xml:space="preserve">
+    <value>Residencia permanente y opciones de tarjeta verde</value>
+  </data>
+        <data name="AsylumDescription" xml:space="preserve">
     <value>Buscando protección y seguridad en Estados Unidos</value>
   </data>
 	<data name="FamilyDescription" xml:space="preserve">


### PR DESCRIPTION
## Summary
- add new Immigrate/Green Card option to home screen
- reorder interview buttons to Visit, Immigrate, Invest, Work, Asylum, Study, Join Family
- reduce margin below welcome text
- update resource files with new strings

## Testing
- `dotnet test --no-build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686ef2ea37688330950cb2c15957a89a