### PR TITLE
Add repository for intake questions and use via API

### DIFF
--- a/Law4Hire.API/Controllers/IntakeController.cs
+++ b/Law4Hire.API/Controllers/IntakeController.cs
@@ -12,9 +12,11 @@ namespace Law4Hire.API.Controllers;
 [Route("api/[controller]")]
 [Authorize]
 [EnableRateLimiting("fixed")]
-public class IntakeController(IIntakeSessionRepository intakeSessionRepository) : ControllerBase
+public class IntakeController(IIntakeSessionRepository intakeSessionRepository,
+    IIntakeQuestionRepository intakeQuestionRepository) : ControllerBase
 {
     private readonly IIntakeSessionRepository _intakeSessionRepository = intakeSessionRepository;
+    private readonly IIntakeQuestionRepository _intakeQuestionRepository = intakeQuestionRepository;
 
     /// <summary>
     /// Create a new intake session
@@ -111,5 +113,26 @@ public class IntakeController(IIntakeSessionRepository intakeSessionRepository) 
         await _intakeSessionRepository.UpdateAsync(session);
 
         return Ok(new { Message = "Progress saved." });
+    }
+
+    [HttpGet("questions")]
+    [AllowAnonymous]
+    public async Task<ActionResult<IEnumerable<IntakeQuestionDto>>> GetQuestions([FromQuery] string category)
+    {
+        var questions = await _intakeQuestionRepository.GetByCategoryAsync(category);
+
+        var dtos = questions.Select(q => new IntakeQuestionDto(
+            q.Id,
+            q.Category,
+            q.QuestionKey,
+            q.QuestionText,
+            q.Type,
+            q.Order,
+            q.Conditions,
+            q.IsRequired,
+            q.ValidationRules
+        ));
+
+        return Ok(dtos);
     }
 }

--- a/Law4Hire.API/Program.cs
+++ b/Law4Hire.API/Program.cs
@@ -56,6 +56,7 @@ builder.Services.AddScoped<IIntakeSessionRepository, IntakeSessionRepository>();
 builder.Services.AddScoped<IServiceRequestRepository, ServiceRequestRepository>();
 builder.Services.AddScoped<ILocalizedContentRepository, LocalizedContentRepository>();
 builder.Services.AddScoped<IVisaTypeRepository, VisaTypeRepository>();
+builder.Services.AddScoped<IIntakeQuestionRepository, IntakeQuestionRepository>();
 builder.Services.AddScoped<IAuthService, AuthService>();
 builder.Services.AddScoped<IIntakeService, IntakeService>();
 builder.Services.AddScoped<IEncryptionService, EncryptionService>();

--- a/Law4Hire.Core/DTOs/IntakeSessionDtos.cs
+++ b/Law4Hire.Core/DTOs/IntakeSessionDtos.cs
@@ -20,6 +20,7 @@ public record CreateIntakeSessionDto(
 
 public record IntakeQuestionDto(
     int Id,
+    string Category,
     string QuestionKey,
     string QuestionText,
     QuestionType Type,
@@ -31,5 +32,4 @@ public record IntakeQuestionDto(
 
 public record UpdateSessionProgressDto(
     int CurrentStep,
-    Dictionary<string, string> Answers
-);
+    Dictionary<string, string> Answers);

--- a/Law4Hire.Core/Entities/IntakeQuestion.cs
+++ b/Law4Hire.Core/Entities/IntakeQuestion.cs
@@ -7,6 +7,9 @@ public class IntakeQuestion
 {
     public int Id { get; set; }
 
+    [MaxLength(50)]
+    public string Category { get; set; } = "General";
+
     [Required]
     [MaxLength(100)]
     public string QuestionKey { get; set; } = string.Empty; // e.g., "full_name", "date_of_birth"

--- a/Law4Hire.Core/Interfaces/IIntakeQuestionRepository.cs
+++ b/Law4Hire.Core/Interfaces/IIntakeQuestionRepository.cs
@@ -1,0 +1,8 @@
+using Law4Hire.Core.Entities;
+
+namespace Law4Hire.Core.Interfaces;
+
+public interface IIntakeQuestionRepository
+{
+    Task<IEnumerable<IntakeQuestion>> GetByCategoryAsync(string category);
+}

--- a/Law4Hire.Infrastructure/Data/DataSeeder.cs
+++ b/Law4Hire.Infrastructure/Data/DataSeeder.cs
@@ -77,6 +77,7 @@ public static class DataSeeder
                 {
                     new IntakeQuestion
                     {
+                        Category = "Visit",
                         QuestionKey = "full_name",
                         QuestionText = "What is your full legal name as it appears on your passport or government-issued ID?",
                         Type = QuestionType.Text,
@@ -86,6 +87,7 @@ public static class DataSeeder
                     },
                     new IntakeQuestion
                     {
+                        Category = "Visit",
                         QuestionKey = "date_of_birth",
                         QuestionText = "What is your date of birth?",
                         Type = QuestionType.Date,
@@ -95,6 +97,7 @@ public static class DataSeeder
                     },
                     new IntakeQuestion
                     {
+                        Category = "Visit",
                         QuestionKey = "country_of_birth",
                         QuestionText = "In which country were you born?",
                         Type = QuestionType.Text,
@@ -104,6 +107,7 @@ public static class DataSeeder
                     },
                     new IntakeQuestion
                     {
+                        Category = "Visit",
                         QuestionKey = "current_immigration_status",
                         QuestionText = "What is your current immigration status in the United States?",
                         Type = QuestionType.MultipleChoice,
@@ -114,6 +118,7 @@ public static class DataSeeder
                     },
                     new IntakeQuestion
                     {
+                        Category = "Visit",
                         QuestionKey = "marriage_status",
                         QuestionText = "What is your current marital status?",
                         Type = QuestionType.MultipleChoice,
@@ -123,6 +128,7 @@ public static class DataSeeder
                     },
                     new IntakeQuestion
                     {
+                        Category = "Visit",
                         QuestionKey = "spouse_citizenship",
                         QuestionText = "What is your spouse's citizenship status?",
                         Type = QuestionType.MultipleChoice,
@@ -133,6 +139,7 @@ public static class DataSeeder
                     },
                     new IntakeQuestion
                     {
+                        Category = "Visit",
                         QuestionKey = "employment_status",
                         QuestionText = "What is your current employment situation in the United States?",
                         Type = QuestionType.MultipleChoice,
@@ -142,6 +149,7 @@ public static class DataSeeder
                     },
                     new IntakeQuestion
                     {
+                        Category = "Visit",
                         QuestionKey = "legal_issues",
                         QuestionText = "Have you ever been arrested, charged with a crime, or had any legal issues in the US or any other country?",
                         Type = QuestionType.MultipleChoice,
@@ -151,6 +159,7 @@ public static class DataSeeder
                     },
                     new IntakeQuestion
                     {
+                        Category = "Visit",
                         QuestionKey = "immigration_goal",
                         QuestionText = "What is your primary immigration goal?",
                         Type = QuestionType.MultipleChoice,

--- a/Law4Hire.Infrastructure/Data/Repositories/IntakeQuestionRepository.cs
+++ b/Law4Hire.Infrastructure/Data/Repositories/IntakeQuestionRepository.cs
@@ -1,0 +1,20 @@
+using Law4Hire.Core.Entities;
+using Law4Hire.Core.Interfaces;
+using Law4Hire.Infrastructure.Data.Contexts;
+using Microsoft.EntityFrameworkCore;
+
+namespace Law4Hire.Infrastructure.Data.Repositories;
+
+public class IntakeQuestionRepository(Law4HireDbContext context) : IIntakeQuestionRepository
+{
+    private readonly Law4HireDbContext _context = context;
+
+    public async Task<IEnumerable<IntakeQuestion>> GetByCategoryAsync(string category)
+    {
+        return await _context.IntakeQuestions
+            .Where(q => q.Category == category)
+            .OrderBy(q => q.Order)
+            .AsNoTracking()
+            .ToListAsync();
+    }
+}

--- a/Law4Hire.Web/Components/Pages/Home.razor
+++ b/Law4Hire.Web/Components/Pages/Home.razor
@@ -236,19 +236,19 @@
     private int goalStartIndex;
     private string? errorMessage;
 
-    protected override void OnInitialized() 
-    { 
-        InitializeSteps();
+    protected override async Task OnInitializedAsync()
+    {
+        await InitializeStepsAsync();
         CultureState.OnChange += OnCultureChanged;
     }
 
-    private void OnCultureChanged()
+    private async void OnCultureChanged()
     {
-        InitializeSteps(); // Reinitialize steps with new culture
+        await InitializeStepsAsync(); // Reinitialize steps with new culture
         InvokeAsync(StateHasChanged);
     }
 
-    private void InitializeSteps()
+    private async Task InitializeStepsAsync()
     {
         var registrationSteps = new List<InterviewStep>
         {
@@ -305,51 +305,27 @@
 
         steps.AddRange(registrationSteps);
         goalStartIndex = steps.Count;
-        steps.AddRange(GetGoalSteps());
+        steps.AddRange(await GetGoalStepsAsync());
     }
-
-    private List<InterviewStep> GetGoalSteps()
+    private async Task<List<InterviewStep>> GetGoalStepsAsync()
     {
-        if (selectedGoal == ImmigrationGoal.Visit)
+        try
         {
-            return new List<InterviewStep>
-            {
-                new InterviewStep
-                {
-                    Question = Localizer["VisitPurposeQuestion"],
-                    PropertyName = "Purpose",
-                    Type = "select",
-                    Options = new List<string>
-                    {
-                        Localizer["PurposeTourism"],
-                        Localizer["PurposeVisitFamily"],
-                        Localizer["PurposeMedical"],
-                        Localizer["PurposeBusiness"],
-                        Localizer["PurposeTransit"],
-                        Localizer["PurposeCrewMember"],
-                        Localizer["PurposeOther"]
-                    }
-                },
-                new InterviewStep
-                {
-                    Question = Localizer["VWPCountryQuestion"],
-                    PropertyName = "VWP",
-                    Type = "radio",
-                    Options = new List<string> { Localizer["Yes"], Localizer["No"] },
-                    Required = true
-                },
-                new InterviewStep
-                {
-                    Question = Localizer["USPaymentQuestion"],
-                    PropertyName = "PaidByUS",
-                    Type = "radio",
-                    Options = new List<string> { Localizer["Yes"], Localizer["No"] },
-                    Required = true
-                }
-            };
-        }
+            var questions = await Http.GetFromJsonAsync<List<IntakeQuestionDto>>($"api/intake/questions?category={selectedGoal}");
+            if (questions == null) return new List<InterviewStep>();
 
-        return new List<InterviewStep>();
+            return questions.Select(q => new InterviewStep
+            {
+                Question = q.QuestionText,
+                PropertyName = q.QuestionKey,
+                Type = q.Type.ToString().ToLower(),
+                Required = q.IsRequired
+            }).ToList();
+        }
+        catch
+        {
+            return new List<InterviewStep>();
+        }
     }
 
     private async Task StartInterview(ImmigrationGoal goal)
@@ -365,7 +341,7 @@
         emailExists = false;
         intakeSessionId = null;
         registrationModel.ImmigrationGoal = goal.ToString();
-        InitializeSteps();
+        await InitializeStepsAsync();
 
         if (AuthState.IsLoggedIn)
         {


### PR DESCRIPTION
## Summary
- add `IIntakeQuestionRepository` and implement `IntakeQuestionRepository`
- support question categories in `IntakeQuestion` entity and sample seed data
- expose `GET /api/intake/questions` endpoint
- register new repository in DI
- load questions from API in Home page

## Testing
- `dotnet test Law4Hire.sln` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686efb145090833099a344fa403d098c