### PR TITLE
Add scheduled visa type updater

### DIFF
--- a/Law4Hire.API/Program.cs
+++ b/Law4Hire.API/Program.cs
@@ -6,6 +6,7 @@ using Law4Hire.Infrastructure.Data;
 using Law4Hire.Infrastructure.Data.Contexts;
 using Law4Hire.Infrastructure.Data.Initialization;
 using Law4Hire.Infrastructure.Data.Repositories;
+using Law4Hire.Infrastructure.Services;
 using Law4Hire.Web.Components;
 using Microsoft.AspNetCore.Authentication.JwtBearer;
 using Microsoft.AspNetCore.Identity;
@@ -61,6 +62,8 @@ builder.Services.AddScoped<IAuthService, AuthService>();
 builder.Services.AddScoped<IIntakeService, IntakeService>();
 builder.Services.AddScoped<IEncryptionService, EncryptionService>();
 builder.Services.AddScoped<IFormIdentificationService, FormIdentificationService>();
+builder.Services.Configure<VisaTypeUpdateOptions>(builder.Configuration.GetSection("VisaTypeUpdate"));
+builder.Services.AddHostedService<VisaTypeUpdateHostedService>();
 builder.Services.AddControllers();
 builder.Services.AddRazorComponents()
     .AddInteractiveServerComponents();

--- a/Law4Hire.API/appsettings.Development.json
+++ b/Law4Hire.API/appsettings.Development.json
@@ -7,6 +7,10 @@
   },
   "ConnectionStrings": {
     "DefaultConnection": "Server=localhost;Database=Law4Hire;Trusted_Connection=True;TrustServerCertificate=True;"
+  },
+  "VisaTypeUpdate": {
+    "DataSource": "visa-types.json",
+    "UpdateIntervalMinutes": 60
   }
 
 }

--- a/Law4Hire.API/appsettings.json
+++ b/Law4Hire.API/appsettings.json
@@ -5,5 +5,9 @@
       "Microsoft.AspNetCore": "Warning"
     }
   },
-  "AllowedHosts": "*"
+  "AllowedHosts": "*",
+  "VisaTypeUpdate": {
+    "DataSource": "visa-types.json",
+    "UpdateIntervalMinutes": 1440
+  }
 }

--- a/Law4Hire.API/appsettings.production.json
+++ b/Law4Hire.API/appsettings.production.json
@@ -5,5 +5,8 @@
       "Microsoft.AspNetCore": "Warning"
     }
   },
-  "AllowedHosts": "*"
-}
+  "AllowedHosts": "*",
+  "VisaTypeUpdate": {
+    "DataSource": "visa-types.json",
+    "UpdateIntervalMinutes": 1440
+  }}

--- a/Law4Hire.API/visa-types.json
+++ b/Law4Hire.API/visa-types.json
@@ -1,0 +1,20 @@
+[
+  {
+    "Id": "00000000-0000-0000-0000-000000000001",
+    "Name": "Tourist Visa",
+    "Description": "Allows short-term visits for tourism and leisure.",
+    "Category": "Non-Immigrant"
+  },
+  {
+    "Id": "00000000-0000-0000-0000-000000000002",
+    "Name": "Student Visa",
+    "Description": "For individuals pursuing academic studies.",
+    "Category": "Non-Immigrant"
+  },
+  {
+    "Id": "00000000-0000-0000-0000-000000000003",
+    "Name": "Employment-Based Immigrant Visa",
+    "Description": "Permanent residency through employment sponsorship.",
+    "Category": "Immigrant"
+  }
+]

--- a/Law4Hire.Application/Services/CoreServices.cs
+++ b/Law4Hire.Application/Services/CoreServices.cs
@@ -169,9 +169,9 @@ public class IntakeService(
         // Return sample questions for now
         return new[]
         {
-            new IntakeQuestionDto(1, "full_name", "What is your full legal name?", QuestionType.Text, 1, null, true, "required,min:2,max:100"),
-            new IntakeQuestionDto(2, "date_of_birth", "What is your date of birth?", QuestionType.Date, 2, null, true, "required,date,before:today"),
-            new IntakeQuestionDto(3, "country_of_birth", "In which country were you born?", QuestionType.Text, 3, null, true, "required,min:2,max:50")
+            new IntakeQuestionDto(1, "Visit", "full_name", "What is your full legal name?", QuestionType.Text, 1, null, true, "required,min:2,max:100"),
+            new IntakeQuestionDto(2, "Visit", "date_of_birth", "What is your date of birth?", QuestionType.Date, 2, null, true, "required,date,before:today"),
+            new IntakeQuestionDto(3, "Visit", "country_of_birth", "In which country were you born?", QuestionType.Text, 3, null, true, "required,min:2,max:50")
         };
     }
 

--- a/Law4Hire.Core/Interfaces/IVisaTypeRepository.cs
+++ b/Law4Hire.Core/Interfaces/IVisaTypeRepository.cs
@@ -7,4 +7,5 @@ public interface IVisaTypeRepository
     Task<IEnumerable<VisaType>> GetAllAsync();
     Task<IEnumerable<VisaType>> GetByCategoryAsync(string category);
     Task<VisaType?> GetByIdAsync(Guid id);
+    Task UpsertRangeAsync(IEnumerable<VisaType> visaTypes);
 }

--- a/Law4Hire.Infrastructure/Data/Repositories/VisaTypeRepository.cs
+++ b/Law4Hire.Infrastructure/Data/Repositories/VisaTypeRepository.cs
@@ -30,4 +30,27 @@ public class VisaTypeRepository(Law4HireDbContext context) : IVisaTypeRepository
             .AsNoTracking()
             .FirstOrDefaultAsync(v => v.Id == id);
     }
+
+    public async Task UpsertRangeAsync(IEnumerable<VisaType> visaTypes)
+    {
+        foreach (var visa in visaTypes)
+        {
+            var existing = await _context.Set<VisaType>()
+                .FirstOrDefaultAsync(v => v.Id == visa.Id);
+
+            if (existing == null)
+            {
+                _context.Set<VisaType>().Add(visa);
+            }
+            else
+            {
+                existing.Name = visa.Name;
+                existing.Description = visa.Description;
+                existing.Category = visa.Category;
+                _context.Set<VisaType>().Update(existing);
+            }
+        }
+
+        await _context.SaveChangesAsync();
+    }
 }

--- a/Law4Hire.Infrastructure/Law4Hire.Infrastructure.csproj
+++ b/Law4Hire.Infrastructure/Law4Hire.Infrastructure.csproj
@@ -11,15 +11,15 @@
 		<ProjectReference Include="..\Law4Hire.Core\Law4Hire.Core.csproj" />
 	</ItemGroup>
 
-	<ItemGroup>
-		<!-- NuGet package references specific to Law4Hire.Infrastructure -->
-		<PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="9.0.6" />
-		<PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="9.0.6">
-		  <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-		  <PrivateAssets>all</PrivateAssets>
-		</PackageReference>
-		<PackageReference Include="Microsoft.Extensions.Identity.Core" Version="9.0.6" />
-		<PackageReference Include="Microsoft.Extensions.Identity.Stores" Version="9.0.6" />
-	</ItemGroup>
-
+        <ItemGroup>
+                <!-- NuGet package references specific to Law4Hire.Infrastructure -->
+                <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="9.0.6" />
+                <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="9.0.6">
+                  <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+                  <PrivateAssets>all</PrivateAssets>
+                </PackageReference>
+                <PackageReference Include="Microsoft.Extensions.Identity.Core" Version="9.0.6" />
+                <PackageReference Include="Microsoft.Extensions.Identity.Stores" Version="9.0.6" />
+                <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="9.0.0" />
+        </ItemGroup>
 </Project>

--- a/Law4Hire.Infrastructure/Services/VisaTypeUpdateHostedService.cs
+++ b/Law4Hire.Infrastructure/Services/VisaTypeUpdateHostedService.cs
@@ -1,0 +1,57 @@
+using System.Text.Json;
+using Law4Hire.Core.Entities;
+using Law4Hire.Core.Interfaces;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+
+namespace Law4Hire.Infrastructure.Services;
+
+public class VisaTypeUpdateHostedService(
+    IVisaTypeRepository visaTypeRepository,
+    IOptions<VisaTypeUpdateOptions> options,
+    ILogger<VisaTypeUpdateHostedService> logger)
+    : BackgroundService
+{
+    private readonly IVisaTypeRepository _repo = visaTypeRepository;
+    private readonly VisaTypeUpdateOptions _options = options.Value;
+    private readonly ILogger<VisaTypeUpdateHostedService> _logger = logger;
+
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        // initial delay to align with schedule if needed
+        while (!stoppingToken.IsCancellationRequested)
+        {
+            try
+            {
+                await UpdateVisaTypesAsync(stoppingToken);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Error updating visa types");
+            }
+
+            await Task.Delay(TimeSpan.FromMinutes(_options.UpdateIntervalMinutes), stoppingToken);
+        }
+    }
+
+    private async Task UpdateVisaTypesAsync(CancellationToken cancellationToken)
+    {
+        if (string.IsNullOrWhiteSpace(_options.DataSource) || !File.Exists(_options.DataSource))
+        {
+            _logger.LogWarning("Visa type data source not found: {Path}", _options.DataSource);
+            return;
+        }
+
+        using var stream = File.OpenRead(_options.DataSource);
+        var visaTypes = await JsonSerializer.DeserializeAsync<List<VisaType>>(stream, cancellationToken: cancellationToken);
+        if (visaTypes == null)
+        {
+            _logger.LogWarning("No visa types found in data source");
+            return;
+        }
+
+        await _repo.UpsertRangeAsync(visaTypes);
+        _logger.LogInformation("Visa types updated: {Count}", visaTypes.Count);
+    }
+}

--- a/Law4Hire.Infrastructure/Services/VisaTypeUpdateOptions.cs
+++ b/Law4Hire.Infrastructure/Services/VisaTypeUpdateOptions.cs
@@ -1,0 +1,14 @@
+namespace Law4Hire.Infrastructure.Services;
+
+public class VisaTypeUpdateOptions
+{
+    /// <summary>
+    /// Interval in minutes between update runs.
+    /// </summary>
+    public int UpdateIntervalMinutes { get; set; } = 60;
+
+    /// <summary>
+    /// Path to the JSON file containing visa type data.
+    /// </summary>
+    public string DataSource { get; set; } = string.Empty;
+}


### PR DESCRIPTION
## Summary
- add `VisaTypeUpdateHostedService` and options to update visa types on a timer
- extend `IVisaTypeRepository` and implement new `UpsertRangeAsync` method
- register hosted service and options in Program
- add sample data file and configuration settings
- fix `GetAvailableQuestionsAsync` sample questions
- add hosting package reference

## Testing
- `dotnet build Law4Hire.API/Law4Hire.API.csproj -c Release`
- `dotnet test tests/Law4Hire.UnitTests/Law4Hire.UnitTests.csproj`
- `dotnet test tests/Law4Hire.IntegrationTests/Law4Hire.IntegrationTests.csproj`
- `dotnet test tests/Law4Hire.E2ETests/Law4Hire.E2ETests.csproj`


------
https://chatgpt.com/codex/tasks/task_e_686effbb2f108330acf7ad20a5df2eb7