### PR TITLE
Fix missing DbSet references

### DIFF
--- a/Law4Hire.Infrastructure/Data/Contexts/Law4HireDbContext.cs
+++ b/Law4Hire.Infrastructure/Data/Contexts/Law4HireDbContext.cs
@@ -22,6 +22,8 @@ public class Law4HireDbContext : IdentityDbContext<User, IdentityRole<Guid>, Gui
     public DbSet<LegalProfessional> LegalProfessionals { get; set; }
     public DbSet<UserDocumentStatus> UserDocumentStatuses { get; set; }
     public DbSet<VisaDocumentRequirement> VisaDocumentRequirements { get; set; }
+    public DbSet<VisaType> VisaTypes { get; set; }
+    public DbSet<DocumentType> DocumentTypes { get; set; }
 
 
     protected override void OnModelCreating(ModelBuilder modelBuilder)


### PR DESCRIPTION
## Summary
- add DbSet properties for VisaTypes and DocumentTypes

## Testing
- `dotnet test --no-build` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_686f08496c848330a851fb011393896c