### PR TITLE
Fix missing IServiceScopeFactory using

### DIFF
--- a/Law4Hire.Infrastructure/Services/VisaTypeUpdateHostedService.cs
+++ b/Law4Hire.Infrastructure/Services/VisaTypeUpdateHostedService.cs
@@ -3,6 +3,7 @@ using Law4Hire.Core.Entities;
 using Law4Hire.Core.Interfaces;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Options;
 
 namespace Law4Hire.Infrastructure.Services;


### PR DESCRIPTION
## Summary
- fix missing `IServiceScopeFactory` using directive

## Testing
- `dotnet build --no-restore` *(fails: current .NET SDK does not support net9.0)*

------
https://chatgpt.com/codex/tasks/task_e_686f0c4fcf60833081ac347bddf30e34