### PR TITLE
Add missing category migration

### DIFF
--- a/Law4Hire.API/Migrations/20250710005807_AutoMigration.Designer.cs
+++ b/Law4Hire.API/Migrations/20250710005807_AutoMigration.Designer.cs
@@ -4,6 +4,7 @@ using Law4Hire.Infrastructure.Data.Contexts;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -11,9 +12,11 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace Law4Hire.API.Migrations
 {
     [DbContext(typeof(Law4HireDbContext))]
-    partial class Law4HireDbContextModelSnapshot : ModelSnapshot
+    [Migration("20250710005807_AutoMigration")]
+    partial class AutoMigration
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/Law4Hire.API/Migrations/20250710005807_AutoMigration.cs
+++ b/Law4Hire.API/Migrations/20250710005807_AutoMigration.cs
@@ -1,0 +1,30 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Law4Hire.API.Migrations
+{
+    /// <inheritdoc />
+    public partial class AutoMigration : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string>(
+                name: "Category",
+                table: "IntakeQuestions",
+                type: "nvarchar(50)",
+                maxLength: 50,
+                nullable: false,
+                defaultValue: "");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "Category",
+                table: "IntakeQuestions");
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add migration for new `Category` column on intake questions

## Testing
- `dotnet build Law4Hire.API/Law4Hire.API.csproj`
- `dotnet ef migrations add AutoMigration --project Law4Hire.API --startup-project Law4Hire.API --context Law4HireDbContext`
- `dotnet ef database update --project Law4Hire.API --startup-project Law4Hire.API --context Law4HireDbContext` *(fails: SQL Server connection not found)*


------
https://chatgpt.com/codex/tasks/task_e_686f0ee6cee08330abe0113507838fe7