### PR TITLE
Add BarState column and profile page

### DIFF
--- a/Law4Hire.API/Controllers/LegalProfessionalController.cs
+++ b/Law4Hire.API/Controllers/LegalProfessionalController.cs
@@ -34,7 +34,8 @@ public class LegalProfessionalController(Law4HireDbContext context) : Controller
         context.LegalProfessionals.Add(new LegalProfessional
         {
             Id = user.Id,
-            BarNumber = dto.BarNumber ?? string.Empty
+            BarNumber = dto.BarNumber ?? string.Empty,
+            BarState = dto.BarState ?? string.Empty
         });
 
         await context.SaveChangesAsync();

--- a/Law4Hire.API/Migrations/20250720000000_AddBarStateToLegalProfessional.cs
+++ b/Law4Hire.API/Migrations/20250720000000_AddBarStateToLegalProfessional.cs
@@ -1,0 +1,29 @@
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Law4Hire.API.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddBarStateToLegalProfessional : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string>(
+                name: "BarState",
+                table: "LegalProfessionals",
+                type: "nvarchar(max)",
+                nullable: false,
+                defaultValue: "");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "BarState",
+                table: "LegalProfessionals");
+        }
+    }
+}

--- a/Law4Hire.API/Migrations/Law4HireDbContextModelSnapshot.cs
+++ b/Law4Hire.API/Migrations/Law4HireDbContextModelSnapshot.cs
@@ -570,6 +570,10 @@ namespace Law4Hire.API.Migrations
                         .IsRequired()
                         .HasColumnType("nvarchar(max)");
 
+                    b.Property<string>("BarState")
+                        .IsRequired()
+                        .HasColumnType("nvarchar(max)");
+
                     b.Property<DateTime>("CreatedAt")
                         .HasColumnType("datetime2");
 

--- a/Law4Hire.Core/DTOs/LegalProfessionalCreateDto.cs
+++ b/Law4Hire.Core/DTOs/LegalProfessionalCreateDto.cs
@@ -8,6 +8,7 @@ public class LegalProfessionalCreateDto
     public required string LastName { get; set; }
     public required string PhoneNumber { get; set; }
     public required string BarNumber { get; set; }
+    public required string BarState { get; set; }
     public required byte[] PasswordHash { get; set; }
     public required byte[] PasswordSalt { get; set; }
     public string? PreferredLanguage { get; set; }

--- a/Law4Hire.Core/Entities/LegalProfessional.cs
+++ b/Law4Hire.Core/Entities/LegalProfessional.cs
@@ -4,6 +4,7 @@ public class LegalProfessional
 {
     public Guid Id { get; set; } // FK to User.Id
     public string BarNumber { get; set; } = string.Empty; // Optional
+    public string BarState { get; set; } = string.Empty; // Licensing state
 
     public DateTime CreatedAt { get; set; } = DateTime.UtcNow;
     public User? User { get; set; }

--- a/Law4Hire.Infrastructure/Data/Initialization/DbInitializer.cs
+++ b/Law4Hire.Infrastructure/Data/Initialization/DbInitializer.cs
@@ -60,7 +60,8 @@ public static class DbInitializer
             context.LegalProfessionals.Add(new LegalProfessional
             {
                 Id = deniseUser.Id,
-                BarNumber = "CN123456"
+                BarNumber = "CN123456",
+                BarState = "CA"
             });
 
             await context.SaveChangesAsync();

--- a/Law4Hire.Web/Components/Layout/NavMenu.razor
+++ b/Law4Hire.Web/Components/Layout/NavMenu.razor
@@ -78,8 +78,14 @@
                 }
                 else if (AuthState.CurrentUser is not null)
                 {
-                    <li class="nav-item">
-                        <a class="nav-link" href="#" @onclick="Logout">Hello @AuthState.CurrentUser.FirstName</a>
+                    <li class="nav-item dropdown">
+                        <a class="nav-link dropdown-toggle" href="#" id="userDropdown" role="button" data-bs-toggle="dropdown" aria-expanded="false">
+                            Hello @AuthState.CurrentUser.FirstName
+                        </a>
+                        <ul class="dropdown-menu dropdown-menu-end" aria-labelledby="userDropdown">
+                            <li><NavLink class="dropdown-item" href="profile">Profile</NavLink></li>
+                            <li><button class="dropdown-item" @onclick="Logout">Logout</button></li>
+                        </ul>
                     </li>
                 }
             </ul>

--- a/Law4Hire.Web/Components/Pages/Profile.razor
+++ b/Law4Hire.Web/Components/Pages/Profile.razor
@@ -1,0 +1,111 @@
+@page "/profile"
+@using System.Net.Http.Json
+@using Law4Hire.Core.DTOs
+@inject HttpClient Http
+@inject Law4Hire.Web.State.AuthState AuthState
+
+<PageTitle>Profile</PageTitle>
+
+@if (AuthState.CurrentUser is null)
+{
+    <p>Please log in to edit your profile.</p>
+}
+else if (editModel is not null)
+{
+    <EditForm Model="editModel" OnValidSubmit="SaveUser">
+        <DataAnnotationsValidator />
+        <div class="mb-2">
+            <label class="form-label">First Name</label>
+            <InputText class="form-control" @bind-Value="editModel.FirstName" />
+        </div>
+        <div class="mb-2">
+            <label class="form-label">Middle Name</label>
+            <InputText class="form-control" @bind-Value="editModel.MiddleName" />
+        </div>
+        <div class="mb-2">
+            <label class="form-label">Last Name</label>
+            <InputText class="form-control" @bind-Value="editModel.LastName" />
+        </div>
+        <div class="mb-2">
+            <label class="form-label">Email</label>
+            <InputText class="form-control" @bind-Value="editModel.Email" />
+        </div>
+        <div class="mb-2">
+            <label class="form-label">Phone</label>
+            <InputText class="form-control" @bind-Value="editModel.PhoneNumber" />
+        </div>
+        <div class="mb-2">
+            <label class="form-label">Address 1</label>
+            <InputText class="form-control" @bind-Value="editModel.Address1" />
+        </div>
+        <div class="mb-2">
+            <label class="form-label">Address 2</label>
+            <InputText class="form-control" @bind-Value="editModel.Address2" />
+        </div>
+        <div class="mb-2">
+            <label class="form-label">City</label>
+            <InputText class="form-control" @bind-Value="editModel.City" />
+        </div>
+        <div class="mb-2">
+            <label class="form-label">State</label>
+            <InputText class="form-control" @bind-Value="editModel.State" />
+        </div>
+        <div class="mb-2">
+            <label class="form-label">Country</label>
+            <InputText class="form-control" @bind-Value="editModel.Country" />
+        </div>
+        <div class="mb-2">
+            <label class="form-label">Postal Code</label>
+            <InputText class="form-control" @bind-Value="editModel.PostalCode" />
+        </div>
+        <div class="mb-3">
+            <label class="form-label">Birthdate</label>
+            <InputDate class="form-control" @bind-Value="editModel.DateOfBirth" />
+        </div>
+        <button class="btn btn-primary btn-sm" type="submit">Save</button>
+    </EditForm>
+}
+
+@code {
+    private UpdateUserDto? editModel;
+
+    protected override void OnInitialized()
+    {
+        if (AuthState.CurrentUser != null)
+        {
+            var u = AuthState.CurrentUser;
+            editModel = new UpdateUserDto
+            {
+                Email = u.Email,
+                FirstName = u.FirstName,
+                MiddleName = u.MiddleName,
+                LastName = u.LastName,
+                PhoneNumber = u.PhoneNumber,
+                PreferredLanguage = u.PreferredLanguage,
+                Address1 = u.Address1,
+                Address2 = u.Address2,
+                City = u.City,
+                State = u.State,
+                Country = u.Country,
+                PostalCode = u.PostalCode,
+                DateOfBirth = u.DateOfBirth
+            };
+        }
+    }
+
+    private async Task SaveUser()
+    {
+        if (editModel is null || AuthState.CurrentUser is null) return;
+
+        var response = await Http.PutAsJsonAsync($"api/users/{AuthState.CurrentUser.Id}", editModel);
+        if (response.IsSuccessStatusCode)
+        {
+            var updated = await response.Content.ReadFromJsonAsync<UserDto>();
+            if (updated != null)
+            {
+                AuthState.SetUser(updated);
+            }
+        }
+    }
+}
+


### PR DESCRIPTION
## Summary
- include a BarState field for legal professionals
- seed default BarState in the initializer
- support BarState via DTOs and controller
- add EF migration and snapshot update
- show a dropdown menu with profile and logout
- create a profile edit page

## Testing
- `dotnet` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686f25406d4c8330b80a0e3acf344341