### PR TITLE
Add Visa Groups and seed script

### DIFF
--- a/Law4Hire.Core/Entities/VisaGroup.cs
+++ b/Law4Hire.Core/Entities/VisaGroup.cs
@@ -1,0 +1,14 @@
+using System.ComponentModel.DataAnnotations;
+using Law4Hire.Core.Enums;
+
+namespace Law4Hire.Core.Entities;
+
+public class VisaGroup
+{
+    [Key]
+    public Guid Id { get; set; }
+    public VisaGroupEnum Name { get; set; }
+    public string? Description { get; set; }
+
+    public ICollection<VisaType> VisaTypes { get; set; } = new List<VisaType>();
+}

--- a/Law4Hire.Core/Entities/VisaType.cs
+++ b/Law4Hire.Core/Entities/VisaType.cs
@@ -8,7 +8,10 @@ public class VisaType
     public Guid Id { get; set; }
     public string Name { get; set; } = null!;
     public string Description { get; set; } = null!;
-    public string Category { get; set; } = null!; // e.g., Non-Immigrant, Immigrant, Asylum
+    public string Category { get; set; } = null!; // legacy category field
+
+    public Guid VisaGroupId { get; set; }
+    public VisaGroup VisaGroup { get; set; } = null!;
 
     public ICollection<VisaDocumentRequirement> DocumentRequirements { get; set; } = new List<VisaDocumentRequirement>();
     public ICollection<UserDocumentStatus> UserDocumentStatuses { get; set; } = new List<UserDocumentStatus>();

--- a/Law4Hire.Core/Enums/VisaGroupEnum.cs
+++ b/Law4Hire.Core/Enums/VisaGroupEnum.cs
@@ -1,0 +1,12 @@
+namespace Law4Hire.Core.Enums;
+
+public enum VisaGroupEnum
+{
+    Visit = 1,
+    Immigrate = 2,
+    Investment = 3,
+    Work = 4,
+    Asylum = 5,
+    Study = 6,
+    Family = 7
+}

--- a/Law4Hire.Infrastructure/Data/Contexts/Law4HireDbContext.cs
+++ b/Law4Hire.Infrastructure/Data/Contexts/Law4HireDbContext.cs
@@ -22,6 +22,7 @@ public class Law4HireDbContext : IdentityDbContext<User, IdentityRole<Guid>, Gui
     public DbSet<LegalProfessional> LegalProfessionals { get; set; }
     public DbSet<UserDocumentStatus> UserDocumentStatuses { get; set; }
     public DbSet<VisaDocumentRequirement> VisaDocumentRequirements { get; set; }
+    public DbSet<VisaGroup> VisaGroups { get; set; }
     public DbSet<VisaType> VisaTypes { get; set; }
     public DbSet<DocumentType> DocumentTypes { get; set; }
 
@@ -42,6 +43,7 @@ public class Law4HireDbContext : IdentityDbContext<User, IdentityRole<Guid>, Gui
             .HasPrecision(18, 2);
 
         modelBuilder.Entity<VisaType>().ToTable("VisaTypes");
+        modelBuilder.Entity<VisaGroup>().ToTable("VisaGroups");
         modelBuilder.Entity<DocumentType>().ToTable("DocumentTypes");
 
         modelBuilder.Entity<UserDocumentStatus>()
@@ -70,10 +72,16 @@ public class Law4HireDbContext : IdentityDbContext<User, IdentityRole<Guid>, Gui
             .HasForeignKey(uds => uds.VisaTypeId)
             .OnDelete(DeleteBehavior.Restrict);
     
-    modelBuilder.Entity<UserVisa>().ToTable("UserVisas")
+        modelBuilder.Entity<UserVisa>().ToTable("UserVisas")
             .HasOne(uv => uv.VisaType)
             .WithMany(vt => vt.UserVisas)
             .HasForeignKey(uv => uv.VisaTypeId);
+
+        modelBuilder.Entity<VisaType>()
+            .HasOne(v => v.VisaGroup)
+            .WithMany(g => g.VisaTypes)
+            .HasForeignKey(v => v.VisaGroupId)
+            .OnDelete(DeleteBehavior.Restrict);
 
         modelBuilder.Entity<UserVisa>()
             .HasOne(uv => uv.User)

--- a/Law4Hire.Infrastructure/Data/DataSeeder.cs
+++ b/Law4Hire.Infrastructure/Data/DataSeeder.cs
@@ -275,10 +275,32 @@ public static class DataSeeder
                 logger?.LogInformation("Added {Count} localized content items", localizedContent.Length);
             }
 
-            // Visa Types
+            // Visa Groups and Types
             if (!await context.VisaTypes.AnyAsync())
             {
                 logger?.LogInformation("Seeding visa types and related data");
+
+                var visitGroupId = Guid.Parse("11111111-1111-1111-1111-111111111111");
+                var immigrateGroupId = Guid.Parse("22222222-2222-2222-2222-222222222222");
+                var investmentGroupId = Guid.Parse("33333333-3333-3333-3333-333333333333");
+                var workGroupId = Guid.Parse("44444444-4444-4444-4444-444444444444");
+                var asylumGroupId = Guid.Parse("55555555-5555-5555-5555-555555555555");
+                var studyGroupId = Guid.Parse("66666666-6666-6666-6666-666666666666");
+                var familyGroupId = Guid.Parse("77777777-7777-7777-7777-777777777777");
+
+                var visaGroups = new[]
+                {
+                    new VisaGroup { Id = visitGroupId, Name = VisaGroupEnum.Visit },
+                    new VisaGroup { Id = immigrateGroupId, Name = VisaGroupEnum.Immigrate },
+                    new VisaGroup { Id = investmentGroupId, Name = VisaGroupEnum.Investment },
+                    new VisaGroup { Id = workGroupId, Name = VisaGroupEnum.Work },
+                    new VisaGroup { Id = asylumGroupId, Name = VisaGroupEnum.Asylum },
+                    new VisaGroup { Id = studyGroupId, Name = VisaGroupEnum.Study },
+                    new VisaGroup { Id = familyGroupId, Name = VisaGroupEnum.Family }
+                };
+
+                await context.VisaGroups.AddRangeAsync(visaGroups);
+                logger?.LogInformation("Added {Count} visa groups", visaGroups.Length);
 
                 var b1b2Id = Guid.Parse("1aa2bf5e-7242-49c2-9303-04ddef44e8b1");
                 var gcFamilyId = Guid.Parse("a8e01e04-27a1-4380-b9cc-cace62830fab");
@@ -293,35 +315,56 @@ public static class DataSeeder
                         Id = b1b2Id,
                         Name = "B1/B2 Visitor Visa",
                         Description = "Temporary visit for business or tourism",
-                        Category = "Visit"
+                        Category = "Visit",
+                        VisaGroupId = visitGroupId
                     },
                     new VisaType
                     {
                         Id = gcFamilyId,
                         Name = "Family Based Green Card",
                         Description = "Immigrate through qualifying family",
-                        Category = "Immigrate"
+                        Category = "Immigrate",
+                        VisaGroupId = immigrateGroupId
                     },
                     new VisaType
                     {
                         Id = f1Id,
                         Name = "F1 Student Visa",
                         Description = "Academic study in the U.S.",
-                        Category = "Study"
+                        Category = "Study",
+                        VisaGroupId = studyGroupId
                     },
                     new VisaType
                     {
                         Id = h1bId,
                         Name = "H1B Specialty Occupation",
                         Description = "Work visa for specialty occupations",
-                        Category = "Work"
+                        Category = "Work",
+                        VisaGroupId = workGroupId
                     },
                     new VisaType
                     {
                         Id = asylumId,
                         Name = "Asylum",
                         Description = "Protection for those fearing persecution",
-                        Category = "Protect"
+                        Category = "Protect",
+                        VisaGroupId = asylumGroupId
+                    },
+                    new VisaType
+                    {
+                        Id = Guid.Parse("88888888-8888-8888-8888-888888888888"),
+                        Name = "EB-5 Immigrant Investor",
+                        Description = "Investment-based path to permanent residence",
+                        Category = "Investment",
+                        VisaGroupId = investmentGroupId
+                    },
+                    new VisaType
+                    {
+                        Id = Guid.Parse("99999999-9999-9999-9999-999999999999"),
+                        Name = "K-1 Fianc\u00E9(e) Visa",
+                        Description = "For foreign-citizen fianc\u00E9s of U.S. citizens",
+                        Category = "Family",
+                        VisaGroupId = familyGroupId
                     }
                 };
 

--- a/seed_visa_groups.sql
+++ b/seed_visa_groups.sql
@@ -1,0 +1,22 @@
+-- Inserts visa group labels and one example visa per group
+-- I WAS UNABLE TO SCAN
+
+-- Visa Groups
+INSERT INTO VisaGroups (Id, Name) VALUES
+  ('11111111-1111-1111-1111-111111111111', 1), -- Visit
+  ('22222222-2222-2222-2222-222222222222', 2), -- Immigrate
+  ('33333333-3333-3333-3333-333333333333', 3), -- Investment
+  ('44444444-4444-4444-4444-444444444444', 4), -- Work
+  ('55555555-5555-5555-5555-555555555555', 5), -- Asylum
+  ('66666666-6666-6666-6666-666666666666', 6), -- Study
+  ('77777777-7777-7777-7777-777777777777', 7); -- Family
+
+-- Visa Types mapped to groups
+INSERT INTO VisaTypes (Id, Name, Description, Category, VisaGroupId) VALUES
+  ('1aa2bf5e-7242-49c2-9303-04ddef44e8b1', 'B1/B2 Visitor Visa', 'Temporary visit for business or tourism', 'Visit', '11111111-1111-1111-1111-111111111111'),
+  ('a8e01e04-27a1-4380-b9cc-cace62830fab', 'Family Based Green Card', 'Immigrate through qualifying family', 'Immigrate', '22222222-2222-2222-2222-222222222222'),
+  ('88888888-8888-8888-8888-888888888888', 'EB-5 Immigrant Investor', 'Investment-based path to permanent residence', 'Investment', '33333333-3333-3333-3333-333333333333'),
+  ('162e3e30-ec8b-438e-8f96-e836465d0908', 'H1B Specialty Occupation', 'Work visa for specialty occupations', 'Work', '44444444-4444-4444-4444-444444444444'),
+  ('a767bd9a-272e-440d-99fc-955e1b1d9303', 'Asylum', 'Protection for those fearing persecution', 'Protect', '55555555-5555-5555-5555-555555555555'),
+  ('cdeb31d4-d778-495b-a4e3-dcd67e1aa737', 'F1 Student Visa', 'Academic study in the U.S.', 'Study', '66666666-6666-6666-6666-666666666666'),
+  ('99999999-9999-9999-9999-999999999999', 'K-1 Fianc\u00e9(e) Visa', 'For foreign-citizen fianc\u00e9s of U.S. citizens', 'Family', '77777777-7777-7777-7777-777777777777');


### PR DESCRIPTION
## Summary
- add `VisaGroup` entity and enum to represent 7 visa categories
- connect `VisaType` to `VisaGroup`
- seed groups and additional visa types in `DataSeeder`
- include SQL script for inserting groups and sample visa types

## Testing
- `dotnet build Law4Hire.sln -c Release` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686f31c001488330a5207d4c433c34b5