### PR TITLE
Fix VisaTypes migration for null groups

### DIFF
--- a/Law4Hire.API/Migrations/20250710033223_00000000000002_GenerateTables.cs
+++ b/Law4Hire.API/Migrations/20250710033223_00000000000002_GenerateTables.cs
@@ -52,6 +52,9 @@ namespace Law4Hire.API.Migrations
             migrationBuilder.Sql("UPDATE VisaTypes SET VisaGroupId = '66666666-6666-6666-6666-666666666666' WHERE Category = 'Study';");
             migrationBuilder.Sql("UPDATE VisaTypes SET VisaGroupId = '77777777-7777-7777-7777-777777777777' WHERE Category = 'Family';");
 
+            // Ensure all existing visa types have an assigned group before making the column non-nullable
+            migrationBuilder.Sql("UPDATE VisaTypes SET VisaGroupId = '11111111-1111-1111-1111-111111111111' WHERE VisaGroupId IS NULL;");
+
             migrationBuilder.AlterColumn<Guid>(
                 name: "VisaGroupId",
                 table: "VisaTypes",


### PR DESCRIPTION
## Summary
- ensure all existing VisaType records have a VisaGroup before making column non-nullable

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686f36f23bcc8330805778216b4babf2