### PR TITLE
Enable conditional pricing link and add interview continuation

### DIFF
--- a/Law4Hire.API/Controllers/UserVisasController.cs
+++ b/Law4Hire.API/Controllers/UserVisasController.cs
@@ -1,0 +1,19 @@
+using Law4Hire.Infrastructure.Data.Contexts;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
+
+namespace Law4Hire.API.Controllers;
+
+[ApiController]
+[Route("api/[controller]")]
+public class UserVisasController(Law4HireDbContext context) : ControllerBase
+{
+    private readonly Law4HireDbContext _context = context;
+
+    [HttpGet("user/{userId:guid}/exists")]
+    public async Task<ActionResult<bool>> UserHasVisa(Guid userId)
+    {
+        var exists = await _context.UserVisas.AnyAsync(u => u.UserId == userId);
+        return Ok(exists);
+    }
+}

--- a/Law4Hire.Web/Components/Layout/NavMenu.razor
+++ b/Law4Hire.Web/Components/Layout/NavMenu.razor
@@ -3,8 +3,10 @@
 @inject IStringLocalizer<NavMenu> Localizer
 @inject Law4Hire.Web.State.CultureState CultureState
 @inject Law4Hire.Web.State.AuthState AuthState
+@inject HttpClient Http
 @using Microsoft.Extensions.Localization
 @using System.Globalization
+@using System.Net.Http.Json
 @implements IDisposable
 
 <header class="top-nav-header">
@@ -33,9 +35,12 @@
                 <li class="nav-item">
                     <NavLink class="nav-link" href="" Match="NavLinkMatch.All">@Localizer["Home"]</NavLink>
                 </li>
-                <li class="nav-item">
-                    <NavLink class="nav-link" href="pricing">@Localizer["Pricing"]</NavLink>
-                </li>
+                @if (hasVisa)
+                {
+                    <li class="nav-item">
+                        <NavLink class="nav-link" href="pricing">@Localizer["Pricing"]</NavLink>
+                    </li>
+                }
                 <li class="nav-item">
                     <NavLink class="nav-link" href="immigrationLibrary">@Localizer["Library"]</NavLink>
                 </li>
@@ -96,11 +101,13 @@
 @code {
     private bool collapseNavMenu = true;
     private string? NavMenuCssClass => collapseNavMenu ? "collapse" : null;
+    private bool hasVisa;
 
-    protected override void OnInitialized()
+    protected override async Task OnInitializedAsync()
     {
-        CultureState.OnChange += StateHasChanged;
-        AuthState.OnChange += StateHasChanged;
+        CultureState.OnChange += OnStateChanged;
+        AuthState.OnChange += OnStateChanged;
+        await LoadVisaStatus();
     }
 
     protected override void OnAfterRender(bool firstRender)
@@ -183,9 +190,33 @@
 
     public record LanguageInfo(string Name, string CultureCode);
 
+    private async void OnStateChanged()
+    {
+        await LoadVisaStatus();
+        StateHasChanged();
+    }
+
+    private async Task LoadVisaStatus()
+    {
+        if (AuthState.CurrentUser == null)
+        {
+            hasVisa = false;
+            return;
+        }
+
+        try
+        {
+            hasVisa = await Http.GetFromJsonAsync<bool>($"api/UserVisas/user/{AuthState.CurrentUser.Id}/exists");
+        }
+        catch
+        {
+            hasVisa = false;
+        }
+    }
+
     public void Dispose()
     {
-        CultureState.OnChange -= StateHasChanged;
-        AuthState.OnChange -= StateHasChanged;
+        CultureState.OnChange -= OnStateChanged;
+        AuthState.OnChange -= OnStateChanged;
     }
 }

--- a/Law4Hire.Web/Components/Pages/Dashboard.razor
+++ b/Law4Hire.Web/Components/Pages/Dashboard.razor
@@ -1,8 +1,10 @@
 @page "/dashboard"
 @using System.Net.Http.Json
 @using Law4Hire.Core.DTOs
+@using System.Linq
 @inject HttpClient Http
 @inject Law4Hire.Web.State.AuthState AuthState
+@inject NavigationManager NavigationManager
 
 <PageTitle>Dashboard</PageTitle>
 
@@ -96,6 +98,12 @@ else
                     {
                         <li>Loading...</li>
                     }
+                    else if (!documents.Any())
+                    {
+                        <li class="text-center">
+                            <button class="btn btn-danger" @onclick="ContinueInterview">Continue Interview</button>
+                        </li>
+                    }
                     else
                     {
                         @foreach (var doc in documents)
@@ -167,6 +175,11 @@ else
                 editMode = false;
             }
         }
+    }
+
+    private void ContinueInterview()
+    {
+        NavigationManager.NavigateTo("/interview/phase2");
     }
 
     private record DocumentInfo(Guid DocumentTypeId, string DocumentName, string Status, string VisaType);

--- a/Law4Hire.Web/Components/Pages/InterviewPhase2.razor
+++ b/Law4Hire.Web/Components/Pages/InterviewPhase2.razor
@@ -1,0 +1,3 @@
+@page "/interview/phase2"
+<h1>Interview Phase 2</h1>
+<p>Continue the interview here.</p>


### PR DESCRIPTION
## Summary
- add `UserVisasController` API endpoint to check if a user has visas
- hide pricing navigation link unless the user has a visa
- show "Continue Interview" button on dashboard when no document statuses exist
- add placeholder page for interview phase 2

## Testing
- `dotnet test --no-build` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_686fee8fa46c8330a40c057d43955cea