### PR TITLE
Add UserVisas collection to DbContext

### DIFF
--- a/Law4Hire.Infrastructure/Data/Contexts/Law4HireDbContext.cs
+++ b/Law4Hire.Infrastructure/Data/Contexts/Law4HireDbContext.cs
@@ -25,6 +25,7 @@ public class Law4HireDbContext : IdentityDbContext<User, IdentityRole<Guid>, Gui
     public DbSet<VisaGroup> VisaGroups { get; set; }
     public DbSet<VisaType> VisaTypes { get; set; }
     public DbSet<DocumentType> DocumentTypes { get; set; }
+    public DbSet<UserVisa> UserVisas { get; set; }
 
 
     protected override void OnModelCreating(ModelBuilder modelBuilder)


### PR DESCRIPTION
## Summary
- add missing `UserVisas` DbSet so API controller compiles

## Testing
- `dotnet restore Law4Hire.API/Law4Hire.API.csproj`
- `dotnet build Law4Hire.API/Law4Hire.API.csproj --no-restore`
- `dotnet test --no-build`

------
https://chatgpt.com/codex/tasks/task_e_68700195ebe083308ab7393df9e77da5