### PR TITLE
Add VisaScraperBot service

### DIFF
--- a/Law4Hire.API/Migrations/20250725000000_AddScrapeLogs.cs
+++ b/Law4Hire.API/Migrations/20250725000000_AddScrapeLogs.cs
@@ -1,0 +1,37 @@
+using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Law4Hire.API.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddScrapeLogs : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "ScrapeLogs",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "uniqueidentifier", nullable: false),
+                    Timestamp = table.Column<DateTime>(type: "datetime2", nullable: false),
+                    Action = table.Column<string>(type: "nvarchar(max)", nullable: false),
+                    EntityAffected = table.Column<string>(type: "nvarchar(max)", nullable: false),
+                    Notes = table.Column<string>(type: "nvarchar(max)", nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_ScrapeLogs", x => x.Id);
+                });
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "ScrapeLogs");
+        }
+    }
+}

--- a/Law4Hire.API/Migrations/Law4HireDbContextModelSnapshot.cs
+++ b/Law4Hire.API/Migrations/Law4HireDbContextModelSnapshot.cs
@@ -514,6 +514,31 @@ namespace Law4Hire.API.Migrations
                     b.ToTable("UserVisas", (string)null);
                 });
 
+            modelBuilder.Entity("Law4Hire.Core.Entities.ScrapeLog", b =>
+                {
+                    b.Property<Guid>("Id")
+                        .ValueGeneratedOnAdd()
+                        .HasColumnType("uniqueidentifier");
+
+                    b.Property<string>("Action")
+                        .IsRequired()
+                        .HasColumnType("nvarchar(max)");
+
+                    b.Property<string>("EntityAffected")
+                        .IsRequired()
+                        .HasColumnType("nvarchar(max)");
+
+                    b.Property<string>("Notes")
+                        .HasColumnType("nvarchar(max)");
+
+                    b.Property<DateTime>("Timestamp")
+                        .HasColumnType("datetime2");
+
+                    b.HasKey("Id");
+
+                    b.ToTable("ScrapeLogs");
+                });
+
             modelBuilder.Entity("Law4Hire.Core.Entities.VisaDocumentRequirement", b =>
                 {
                     b.Property<Guid>("Id")

--- a/Law4Hire.API/Program.cs
+++ b/Law4Hire.API/Program.cs
@@ -57,6 +57,7 @@ builder.Services.AddScoped<IIntakeSessionRepository, IntakeSessionRepository>();
 builder.Services.AddScoped<IServiceRequestRepository, ServiceRequestRepository>();
 builder.Services.AddScoped<ILocalizedContentRepository, LocalizedContentRepository>();
 builder.Services.AddScoped<IVisaTypeRepository, VisaTypeRepository>();
+builder.Services.AddScoped<IScrapeLogRepository, ScrapeLogRepository>();
 builder.Services.AddScoped<IIntakeQuestionRepository, IntakeQuestionRepository>();
 builder.Services.AddScoped<IAuthService, AuthService>();
 builder.Services.AddScoped<IIntakeService, IntakeService>();

--- a/Law4Hire.Core/Entities/ScrapeLog.cs
+++ b/Law4Hire.Core/Entities/ScrapeLog.cs
@@ -1,0 +1,13 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace Law4Hire.Core.Entities;
+
+public class ScrapeLog
+{
+    [Key]
+    public Guid Id { get; set; }
+    public DateTime Timestamp { get; set; }
+    public string Action { get; set; } = string.Empty;
+    public string EntityAffected { get; set; } = string.Empty;
+    public string? Notes { get; set; }
+}

--- a/Law4Hire.Core/Interfaces/IScrapeLogRepository.cs
+++ b/Law4Hire.Core/Interfaces/IScrapeLogRepository.cs
@@ -1,0 +1,8 @@
+using Law4Hire.Core.Entities;
+
+namespace Law4Hire.Core.Interfaces;
+
+public interface IScrapeLogRepository
+{
+    Task AddAsync(ScrapeLog log);
+}

--- a/Law4Hire.Infrastructure/Data/Contexts/Law4HireDbContext.cs
+++ b/Law4Hire.Infrastructure/Data/Contexts/Law4HireDbContext.cs
@@ -26,6 +26,7 @@ public class Law4HireDbContext : IdentityDbContext<User, IdentityRole<Guid>, Gui
     public DbSet<VisaType> VisaTypes { get; set; }
     public DbSet<DocumentType> DocumentTypes { get; set; }
     public DbSet<UserVisa> UserVisas { get; set; }
+    public DbSet<ScrapeLog> ScrapeLogs { get; set; }
 
 
     protected override void OnModelCreating(ModelBuilder modelBuilder)

--- a/Law4Hire.Infrastructure/Data/Repositories/ScrapeLogRepository.cs
+++ b/Law4Hire.Infrastructure/Data/Repositories/ScrapeLogRepository.cs
@@ -1,0 +1,16 @@
+using Law4Hire.Core.Entities;
+using Law4Hire.Core.Interfaces;
+using Law4Hire.Infrastructure.Data.Contexts;
+
+namespace Law4Hire.Infrastructure.Data.Repositories;
+
+public class ScrapeLogRepository(Law4HireDbContext context) : IScrapeLogRepository
+{
+    private readonly Law4HireDbContext _context = context;
+
+    public async Task AddAsync(ScrapeLog log)
+    {
+        _context.ScrapeLogs.Add(log);
+        await _context.SaveChangesAsync();
+    }
+}

--- a/Law4Hire.Scraper/Law4Hire.Scraper.csproj
+++ b/Law4Hire.Scraper/Law4Hire.Scraper.csproj
@@ -12,4 +12,10 @@
     <Nullable>enable</Nullable>
   </PropertyGroup>
 
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.Hosting" Version="9.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="9.0.0" />
+    <PackageReference Include="PlaywrightSharp" Version="0.192.0" />
+  </ItemGroup>
+
 </Project>

--- a/Law4Hire.Scraper/Program.cs
+++ b/Law4Hire.Scraper/Program.cs
@@ -1,2 +1,20 @@
-﻿// See https://aka.ms/new-console-template for more information
-Console.WriteLine("Hello, World!");
+using Law4Hire.Core.Interfaces;
+using Law4Hire.Infrastructure.Data.Contexts;
+using Law4Hire.Infrastructure.Data.Repositories;
+using Law4Hire.Scraper;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+
+var host = Host.CreateDefaultBuilder(args)
+    .ConfigureServices((context, services) =>
+    {
+        var connection = context.Configuration.GetConnectionString("DefaultConnection");
+        services.AddDbContext<Law4HireDbContext>(options => options.UseSqlServer(connection));
+        services.AddScoped<IVisaTypeRepository, VisaTypeRepository>();
+        services.AddScoped<IScrapeLogRepository, ScrapeLogRepository>();
+        services.AddHostedService<VisaScraperBot>();
+    })
+    .Build();
+
+await host.RunAsync();

--- a/Law4Hire.Scraper/VisaScraperBot.cs
+++ b/Law4Hire.Scraper/VisaScraperBot.cs
@@ -1,0 +1,111 @@
+using System.Text.RegularExpressions;
+using Law4Hire.Core.Entities;
+using Law4Hire.Core.Interfaces;
+using Law4Hire.Infrastructure.Data.Contexts;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using PlaywrightSharp;
+
+namespace Law4Hire.Scraper;
+
+public class VisaScraperBot(
+    IServiceScopeFactory scopeFactory,
+    ILogger<VisaScraperBot> logger) : BackgroundService
+{
+    private readonly IServiceScopeFactory _scopeFactory = scopeFactory;
+    private readonly ILogger<VisaScraperBot> _logger = logger;
+    private const string SourceUrl = "https://travel.state.gov/content/travel/en/us-visas/visa-information-resources/all-visa-categories.html";
+
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        try
+        {
+            var scraped = await ScrapeVisaTypesAsync(stoppingToken);
+            using var scope = _scopeFactory.CreateScope();
+            var db = scope.ServiceProvider.GetRequiredService<Law4HireDbContext>();
+            var logRepo = scope.ServiceProvider.GetRequiredService<IScrapeLogRepository>();
+
+            foreach (var visa in scraped)
+            {
+                var exists = await db.VisaTypes.FirstOrDefaultAsync(v => v.Name == visa.Name, cancellationToken: stoppingToken);
+                if (exists == null)
+                {
+                    db.VisaTypes.Add(visa);
+                    await db.SaveChangesAsync(stoppingToken);
+                    await logRepo.AddAsync(new ScrapeLog
+                    {
+                        Id = Guid.NewGuid(),
+                        Timestamp = DateTime.UtcNow,
+                        Action = "Created",
+                        EntityAffected = visa.Name,
+                        Notes = SourceUrl
+                    });
+                }
+                else
+                {
+                    await logRepo.AddAsync(new ScrapeLog
+                    {
+                        Id = Guid.NewGuid(),
+                        Timestamp = DateTime.UtcNow,
+                        Action = "Skipped",
+                        EntityAffected = exists.Name,
+                        Notes = "Already exists"
+                    });
+                }
+            }
+        }
+        catch (Exception ex)
+        {
+            using var scope = _scopeFactory.CreateScope();
+            var logRepo = scope.ServiceProvider.GetRequiredService<IScrapeLogRepository>();
+            await logRepo.AddAsync(new ScrapeLog
+            {
+                Id = Guid.NewGuid(),
+                Timestamp = DateTime.UtcNow,
+                Action = "Error",
+                EntityAffected = "VisaScraperBot",
+                Notes = ex.Message
+            });
+            _logger.LogError(ex, "Scraper failed");
+        }
+    }
+
+    private static async Task<List<VisaType>> ScrapeVisaTypesAsync(CancellationToken token)
+    {
+        var list = new List<VisaType>();
+        using var playwright = await Playwright.CreateAsync();
+        await using var browser = await playwright.Chromium.LaunchAsync(new BrowserTypeLaunchOptions { Headless = true });
+        var page = await browser.NewPageAsync();
+        await page.GoToAsync(SourceUrl);
+        var rows = await page.QuerySelectorAllAsync("table.grid tbody tr");
+        var map = new Dictionary<string, Guid>
+        {
+            {"B-1", Guid.Parse("11111111-1111-1111-1111-111111111111")},
+            {"B-2", Guid.Parse("11111111-1111-1111-1111-111111111111")},
+            {"J", Guid.Parse("66666666-6666-6666-6666-666666666666")},
+            {"O", Guid.Parse("44444444-4444-4444-4444-444444444444")}
+        };
+
+        foreach (var row in rows)
+        {
+            var cells = await row.QuerySelectorAllAsync("td");
+            if (cells.Length < 2) continue;
+            var desc = (await (await cells[0].GetPropertyAsync("innerText")).JsonValueAsync<string>()).Trim();
+            var visaName = (await (await cells[1].GetPropertyAsync("innerText")).JsonValueAsync<string>()).Trim();
+            visaName = Regex.Replace(visaName, "\s+", " ");
+            if (string.IsNullOrWhiteSpace(visaName)) continue;
+            list.Add(new VisaType
+            {
+                Id = Guid.NewGuid(),
+                Name = visaName,
+                Description = desc,
+                Category = "Unknown",
+                VisaGroupId = map.TryGetValue(visaName, out var gid) ? gid : Guid.Parse("11111111-1111-1111-1111-111111111111")
+            });
+        }
+
+        return list;
+    }
+}

--- a/Law4Hire.Scraper/appsettings.json
+++ b/Law4Hire.Scraper/appsettings.json
@@ -1,0 +1,5 @@
+{
+  "ConnectionStrings": {
+    "DefaultConnection": "Server=localhost;Database=Law4Hire;Trusted_Connection=True;TrustServerCertificate=True;"
+  }
+}


### PR DESCRIPTION
## Summary
- create `ScrapeLog` entity and repository
- add DB context set and migration for `ScrapeLogs`
- register repository in API
- add Playwright based `VisaScraperBot` background service
- wire scraper bot console app

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687041dde07083309210540714a51e7e