### PR TITLE
Add visa type question infrastructure

### DIFF
--- a/Law4Hire.API/Controllers/VisaTypeQuestionsController.cs
+++ b/Law4Hire.API/Controllers/VisaTypeQuestionsController.cs
@@ -1,0 +1,21 @@
+using Law4Hire.Core.Entities;
+using Law4Hire.Core.Interfaces;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+
+namespace Law4Hire.API.Controllers;
+
+[ApiController]
+[Route("api/[controller]")]
+public class VisaTypeQuestionsController(IVisaTypeQuestionRepository repository) : ControllerBase
+{
+    private readonly IVisaTypeQuestionRepository _repository = repository;
+
+    [HttpGet("visa/{visaTypeId:guid}")]
+    [AllowAnonymous]
+    public async Task<ActionResult<IEnumerable<VisaTypeQuestion>>> GetByVisa(Guid visaTypeId)
+    {
+        var questions = await _repository.GetByVisaTypeIdAsync(visaTypeId);
+        return Ok(questions);
+    }
+}

--- a/Law4Hire.API/Program.cs
+++ b/Law4Hire.API/Program.cs
@@ -59,6 +59,7 @@ builder.Services.AddScoped<ILocalizedContentRepository, LocalizedContentReposito
 builder.Services.AddScoped<IVisaTypeRepository, VisaTypeRepository>();
 builder.Services.AddScoped<IScrapeLogRepository, ScrapeLogRepository>();
 builder.Services.AddScoped<IIntakeQuestionRepository, IntakeQuestionRepository>();
+builder.Services.AddScoped<IVisaTypeQuestionRepository, VisaTypeQuestionRepository>();
 builder.Services.AddScoped<IAuthService, AuthService>();
 builder.Services.AddScoped<IIntakeService, IntakeService>();
 builder.Services.AddScoped<IEncryptionService, EncryptionService>();

--- a/Law4Hire.Core/Entities/VisaTypeQuestion.cs
+++ b/Law4Hire.Core/Entities/VisaTypeQuestion.cs
@@ -1,0 +1,31 @@
+using System.ComponentModel.DataAnnotations;
+using Law4Hire.Core.Enums;
+
+namespace Law4Hire.Core.Entities;
+
+public class VisaTypeQuestion
+{
+    [Key]
+    public Guid Id { get; set; }
+
+    [Required]
+    public Guid VisaTypeId { get; set; }
+    public VisaType VisaType { get; set; } = null!;
+
+    [Required]
+    [MaxLength(100)]
+    public string QuestionKey { get; set; } = string.Empty;
+
+    [Required]
+    [MaxLength(500)]
+    public string QuestionText { get; set; } = string.Empty;
+
+    public QuestionType Type { get; set; }
+
+    public int Order { get; set; }
+
+    public bool IsRequired { get; set; }
+
+    [MaxLength(1000)]
+    public string? ValidationRules { get; set; }
+}

--- a/Law4Hire.Core/Interfaces/IVisaTypeQuestionRepository.cs
+++ b/Law4Hire.Core/Interfaces/IVisaTypeQuestionRepository.cs
@@ -1,0 +1,9 @@
+using Law4Hire.Core.Entities;
+
+namespace Law4Hire.Core.Interfaces;
+
+public interface IVisaTypeQuestionRepository
+{
+    Task<IEnumerable<VisaTypeQuestion>> GetByVisaTypeIdAsync(Guid visaTypeId);
+    Task UpsertRangeAsync(IEnumerable<VisaTypeQuestion> questions);
+}

--- a/Law4Hire.Infrastructure/Data/Contexts/Law4HireDbContext.cs
+++ b/Law4Hire.Infrastructure/Data/Contexts/Law4HireDbContext.cs
@@ -27,6 +27,7 @@ public class Law4HireDbContext : IdentityDbContext<User, IdentityRole<Guid>, Gui
     public DbSet<DocumentType> DocumentTypes { get; set; }
     public DbSet<UserVisa> UserVisas { get; set; }
     public DbSet<ScrapeLog> ScrapeLogs { get; set; }
+    public DbSet<VisaTypeQuestion> VisaTypeQuestions { get; set; }
 
 
     protected override void OnModelCreating(ModelBuilder modelBuilder)
@@ -78,6 +79,12 @@ public class Law4HireDbContext : IdentityDbContext<User, IdentityRole<Guid>, Gui
             .HasOne(uv => uv.VisaType)
             .WithMany(vt => vt.UserVisas)
             .HasForeignKey(uv => uv.VisaTypeId);
+
+        modelBuilder.Entity<VisaTypeQuestion>()
+            .HasOne(vq => vq.VisaType)
+            .WithMany()
+            .HasForeignKey(vq => vq.VisaTypeId)
+            .OnDelete(DeleteBehavior.Cascade);
 
         modelBuilder.Entity<VisaType>()
             .HasOne(v => v.VisaGroup)

--- a/Law4Hire.Infrastructure/Data/Repositories/VisaTypeQuestionRepository.cs
+++ b/Law4Hire.Infrastructure/Data/Repositories/VisaTypeQuestionRepository.cs
@@ -1,0 +1,47 @@
+using Law4Hire.Core.Entities;
+using Law4Hire.Core.Interfaces;
+using Law4Hire.Infrastructure.Data.Contexts;
+using Microsoft.EntityFrameworkCore;
+
+namespace Law4Hire.Infrastructure.Data.Repositories;
+
+public class VisaTypeQuestionRepository(Law4HireDbContext context) : IVisaTypeQuestionRepository
+{
+    private readonly Law4HireDbContext _context = context;
+
+    public async Task<IEnumerable<VisaTypeQuestion>> GetByVisaTypeIdAsync(Guid visaTypeId)
+    {
+        return await _context.Set<VisaTypeQuestion>()
+            .Where(q => q.VisaTypeId == visaTypeId)
+            .OrderBy(q => q.Order)
+            .AsNoTracking()
+            .ToListAsync();
+    }
+
+    public async Task UpsertRangeAsync(IEnumerable<VisaTypeQuestion> questions)
+    {
+        foreach (var question in questions)
+        {
+            var existing = await _context.Set<VisaTypeQuestion>()
+                .FirstOrDefaultAsync(q => q.Id == question.Id);
+
+            if (existing == null)
+            {
+                _context.Set<VisaTypeQuestion>().Add(question);
+            }
+            else
+            {
+                existing.QuestionKey = question.QuestionKey;
+                existing.QuestionText = question.QuestionText;
+                existing.Type = question.Type;
+                existing.Order = question.Order;
+                existing.IsRequired = question.IsRequired;
+                existing.ValidationRules = question.ValidationRules;
+                existing.VisaTypeId = question.VisaTypeId;
+                _context.Set<VisaTypeQuestion>().Update(existing);
+            }
+        }
+
+        await _context.SaveChangesAsync();
+    }
+}

--- a/add_visa_type_questions.sql
+++ b/add_visa_type_questions.sql
@@ -1,0 +1,15 @@
+CREATE TABLE IF NOT EXISTS VisaTypeQuestions (
+    Id UNIQUEIDENTIFIER PRIMARY KEY,
+    VisaTypeId UNIQUEIDENTIFIER NOT NULL,
+    QuestionKey NVARCHAR(100) NOT NULL,
+    QuestionText NVARCHAR(500) NOT NULL,
+    Type INT NOT NULL,
+    [Order] INT NOT NULL,
+    IsRequired BIT NOT NULL,
+    ValidationRules NVARCHAR(1000) NULL,
+    CONSTRAINT FK_VisaTypeQuestions_VisaTypes FOREIGN KEY (VisaTypeId) REFERENCES VisaTypes(Id)
+);
+
+-- Sample question for B1/B2 visitor visa
+INSERT INTO VisaTypeQuestions (Id, VisaTypeId, QuestionKey, QuestionText, Type, [Order], IsRequired, ValidationRules)
+VALUES ('11111111-2222-3333-4444-555555555555', '1aa2bf5e-7242-49c2-9303-04ddef44e8b1', 'has_us_sponsor', 'Do you have a U.S. sponsor?', 3, 1, 1, '{"required": true, "options": ["Yes","No"]}');


### PR DESCRIPTION
## Summary
- support visa-specific interview questions
- wire up repository and controller
- SQL script for creating VisaTypeQuestions table

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687416d8d1e883309a78793de9fd4e89