### PR TITLE
Fix compile errors in scraper and home page

### DIFF
--- a/Law4Hire.Scraper/VisaScraperBot.cs
+++ b/Law4Hire.Scraper/VisaScraperBot.cs
@@ -76,7 +76,7 @@ public class VisaScraperBot(
     {
         var list = new List<VisaType>();
         using var playwright = await Playwright.CreateAsync();
-        await using var browser = await playwright.Chromium.LaunchAsync(new BrowserTypeLaunchOptions { Headless = true });
+        await using var browser = await playwright.Chromium.LaunchAsync(new LaunchOptions { Headless = true });
         var page = await browser.NewPageAsync();
         await page.GoToAsync(SourceUrl);
         var rows = await page.QuerySelectorAllAsync("table.grid tbody tr");
@@ -94,7 +94,7 @@ public class VisaScraperBot(
             if (cells.Length < 2) continue;
             var desc = (await (await cells[0].GetPropertyAsync("innerText")).JsonValueAsync<string>()).Trim();
             var visaName = (await (await cells[1].GetPropertyAsync("innerText")).JsonValueAsync<string>()).Trim();
-            visaName = Regex.Replace(visaName, "\s+", " ");
+            visaName = Regex.Replace(visaName, "\\s+", " ");
             if (string.IsNullOrWhiteSpace(visaName)) continue;
             list.Add(new VisaType
             {

--- a/Law4Hire.Web/Components/Pages/Home.razor
+++ b/Law4Hire.Web/Components/Pages/Home.razor
@@ -265,7 +265,7 @@
     private async void OnCultureChanged()
     {
         await InitializeStepsAsync(); // Reinitialize steps with new culture
-        InvokeAsync(StateHasChanged);
+        await InvokeAsync(StateHasChanged);
     }
 
     private void OnAuthChanged()


### PR DESCRIPTION
## Summary
- ensure regex pattern is escaped in Visa scraper
- use `LaunchOptions` with PlaywrightSharp
- await InvokeAsync in Home page

## Testing
- `dotnet restore` *(fails: current .NET SDK does not support net9.0)*

------
https://chatgpt.com/codex/tasks/task_e_6874226251cc8330b1c8b9f652018634