### PR TITLE
Fix scraper bot compile errors

### DIFF
--- a/Law4Hire.Scraper/Program.cs
+++ b/Law4Hire.Scraper/Program.cs
@@ -3,6 +3,7 @@ using Law4Hire.Infrastructure.Data.Contexts;
 using Law4Hire.Infrastructure.Data.Repositories;
 using Law4Hire.Scraper;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 

--- a/Law4Hire.Scraper/VisaScraperBot.cs
+++ b/Law4Hire.Scraper/VisaScraperBot.cs
@@ -90,10 +90,10 @@ public class VisaScraperBot(
 
         foreach (var row in rows)
         {
-            var cells = await row.QuerySelectorAllAsync("td");
+            var cells = (await row.QuerySelectorAllAsync("td")).ToArray();
             if (cells.Length < 2) continue;
-            var desc = (await (await cells[0].GetPropertyAsync("innerText")).JsonValueAsync<string>()).Trim();
-            var visaName = (await (await cells[1].GetPropertyAsync("innerText")).JsonValueAsync<string>()).Trim();
+            var desc = (await (await cells[0].GetPropertyAsync("innerText")).GetJsonValueAsync<string>()).Trim();
+            var visaName = (await (await cells[1].GetPropertyAsync("innerText")).GetJsonValueAsync<string>()).Trim();
             visaName = Regex.Replace(visaName, "\\s+", " ");
             if (string.IsNullOrWhiteSpace(visaName)) continue;
             list.Add(new VisaType


### PR DESCRIPTION
## Summary
- include configuration namespace for `GetConnectionString`
- convert scraper cell collection to an array
- use `GetJsonValueAsync` on IJSHandle

## Testing
- `dotnet build Law4Hire.Scraper/Law4Hire.Scraper.csproj --no-restore`
- `dotnet test tests/Law4Hire.UnitTests/Law4Hire.UnitTests.csproj --verbosity normal`

------
https://chatgpt.com/codex/tasks/task_e_687426f8ac6c833093b8872f49e27a24