### PR TITLE
Update dev container to use latest Node and dotnet-install

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,36 @@
+FROM ubuntu:22.04
+
+# Avoid prompts during install
+ENV DEBIAN_FRONTEND=noninteractive
+
+# Update apt and install dependencies
+RUN apt-get update && apt-get install -y \
+    curl \
+    wget \
+    gnupg \
+    ca-certificates \
+    apt-transport-https \
+    software-properties-common \
+    lsb-release
+
+# Install latest Node.js
+RUN curl -fsSL https://deb.nodesource.com/setup_current.x | bash - && \
+    apt-get install -y nodejs
+
+# Install .NET 9 SDK using dotnet-install script
+RUN wget https://dot.net/v1/dotnet-install.sh -O dotnet-install.sh && \
+    chmod +x dotnet-install.sh && \
+    ./dotnet-install.sh --channel 9.0 && \
+    rm dotnet-install.sh
+
+# Configure .NET environment
+ENV DOTNET_ROOT="/root/.dotnet"
+ENV PATH="$PATH:/root/.dotnet:/root/.dotnet/tools"
+
+# Install PostgreSQL
+RUN apt-get install -y postgresql
+
+# Clean up apt caches
+RUN apt-get clean && rm -rf /var/lib/apt/lists/*
+
+CMD ["/bin/bash"]

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,10 @@
+{
+    "name": "Law4Hire Dev Container",
+    "build": {
+        "dockerfile": "Dockerfile"
+    },
+    "settings": {
+        "terminal.integrated.defaultProfile.linux": "bash"
+    },
+    "postCreateCommand": "dotnet --version && node --version && psql --version"
+}

--- a/README.md
+++ b/README.md
@@ -1,0 +1,14 @@
+# Law4Hire
+
+This repository includes a `.devcontainer` definition for working in a development environment based on **Ubuntu 22.04** with:
+
+- **Node.js** (latest)
+- **.NET 9 SDK**
+- **PostgreSQL**
+
+## Using the Dev Container
+
+1. Install [VS Code](https://code.visualstudio.com/) and the [Dev Containers extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.remote-containers).
+2. Open the project in VS Code and reopen it in the container when prompted. The container uses Microsoft's `dotnet-install.sh` script to install the .NET 9 SDK.
+
+The environment exposes `dotnet`, `node`, and `psql` commands from the integrated terminal.


### PR DESCRIPTION
## Summary
- adjust Dockerfile to install Node.js from the current channel
- install .NET 9 using `dotnet-install.sh`
- expose .NET in PATH and document the install method

## Testing
- `dotnet test` *(failed: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687978815d30833091e33cd1220ca10f